### PR TITLE
Copying the LICENSE file to new folder for UBI

### DIFF
--- a/11/jdk/ubi/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/Dockerfile.open.releases.full
@@ -55,6 +55,8 @@ RUN set -eux; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
     tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    mkdir -p /licenses; \
+    cp /opt/java/openjdk/legal/java.base/LICENSE /licenses; \
     rm -rf /tmp/openjdk.tar.gz;
 
 ENV JAVA_HOME=/opt/java/openjdk \


### PR DESCRIPTION
The fix is to copy the License file to "/licenses" folder for UBI images. This is needed for publishing the images at RH registry. 