### PR TITLE
Update GitHub Actions to use new bashbrew action

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -14,18 +14,16 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
+      - uses: docker-library/bashbrew@v0.1.5
       - id: generate-jobs
         name: Generate Jobs
         run: |
           export GENERATE_STACKBREW_LIBRARY='./dockerhub_doc_config_update.sh /dev/stdout'
           export GITHUB_REPOSITORY="eclipse-temurin"
-          git clone --depth 1 https://github.com/docker-library/bashbrew.git -b master ~/bashbrew
-          strategy="$(~/bashbrew/scripts/github-actions/generate.sh)"
+          strategy="$("$BASHBREW_SCRIPTS/github-actions/generate.sh")"
+          echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
           jq . <<<"$strategy" # sanity check / debugging aid
-          echo "::set-output name=strategy::$strategy"
 
   test:
     needs: generate-jobs
@@ -33,7 +31,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies


### PR DESCRIPTION
This should fix errors that the old code would've run into thanks to the update to Go 1.18, and should help prevent them in the future by pinning to a specific release of both Bashbrew and the related scripts.

See also docker-library/bashbrew#57