### PR TITLE
Add semeru-ea binaries

### DIFF
--- a/17-ea/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17-ea/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -1,0 +1,142 @@
+# (C) Copyright IBM Corporation 2022, 2023
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+# Artifactory credentials to download CRIU binary
+# Set your Artifactory credentials here or pass them at build time
+ARG ARTIFACTORY_TOKEN
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN dnf install -y \
+    # CRIU dependencies
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+    # Semeru dependencies
+        tzdata openssl curl ca-certificates fontconfig glibc-langpack-en gzip tar \
+    # other dependencies
+        python3 \
+    && dnf update -y; dnf clean all;
+
+LABEL name="IBM Semeru Runtime EA" \
+      vendor="International Business Machines Corporation" \
+      version="17.0.6.6" \
+      release="17" \
+      run="docker run --rm -ti <image_name:tag> /bin/bash" \
+      summary="IBM Semeru Runtime EA Docker Image for OpenJDK with openj9 and ubi" \
+      description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
+
+# Install CRIU
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    case "${ARCH}" in \
+       amd64|x86_64) \
+          CRIU_URL='https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/hyc-runtimes-jenkins.swg-devops.com/build-scripts/criu_build/3/criu.tar.gz'; \
+          CRIU_SHA_URL='https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/hyc-runtimes-jenkins.swg-devops.com/build-scripts/criu_build/3/criu.tar.gz.sha256.txt'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    cd /tmp; \
+    curl -H X-JFrog-Art-Api:${ARTIFACTORY_TOKEN} -LfsSo criu.tar.gz ${CRIU_URL};\
+    curl -H X-JFrog-Art-Api:${ARTIFACTORY_TOKEN} -LfsSo criu.tar.gz.sha256.txt ${CRIU_SHA_URL};\
+    sha256sum -c criu.tar.gz.sha256.txt; \
+    tar -xzf criu.tar.gz --strip-components=1; \
+    cp -R usr/local /usr; \
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/criu.conf; \
+    ldconfig; \
+    setcap cap_checkpoint_restore,cap_sys_ptrace=eip /usr/local/sbin/criu; \
+    rm -fr criu criu.tar.gz;
+
+ENV PATH="/usr/local/sbin:$PATH"
+
+ENV JAVA_VERSION 17.0.6.6
+
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    case "${ARCH}" in \
+       amd64|x86_64) \
+         ESUM='8ead64de8d19a360eb819afd57cdc0b40eef23edeb9e2aef05036801cd2fd3c7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-ea-binaries/releases/download/jdk-17.0.6%2B6_december_22-preview_1/ibm-semeru-open-ea-jdk_x64_linux_17.0.6_6_December_22-preview_1.tar.gz'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/java/java-ea; \
+    cd /opt/java/java-ea; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1;
+
+ENV JAVA_HOME=/opt/java/java-ea \
+    PATH="/opt/java/java-ea/bin:$PATH"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+PortableSharedCache -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
+
+# Create OpenJ9 SharedClassCache (SCC) for bootclasses to improve the java startup.
+# Downloads and runs tomcat to generate SCC for bootclasses at /opt/java/.scc/openj9_system_scc
+# Does a dry-run and calculates the optimal cache size and recreates the cache with the appropriate size.
+# With SCC, OpenJ9 startup is improved ~50% with an increase in image size of ~14MB
+# Application classes can be create a separate cache layer with this as the base for further startup improvement
+
+RUN set -eux; \
+    unset OPENJ9_JAVA_OPTIONS; \
+    SCC_SIZE="50m"; \
+    DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
+    INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
+    TOMCAT_CHECKSUM="0db27185d9fc3174f2c670f814df3dda8a008b89d1a38a5d96cbbe119767ebfb1cf0bce956b27954aee9be19c4a7b91f2579d967932207976322033a86075f98"; \
+    TOMCAT_DWNLD_URL="https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.35/bin/apache-tomcat-9.0.35.tar.gz"; \
+    \
+    mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
+    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
+    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
+    rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
+    \
+    java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version; \
+    export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal"; \
+    "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
+    sleep 5; \
+    "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh -force; \
+    sleep 15; \
+    FULL=$( (java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'); \
+    DST_CACHE=$(java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,destroy 2>&1 || true); \
+    SCC_SIZE=$(echo $SCC_SIZE | sed 's/.$//'); \
+    SCC_SIZE=$(awk "BEGIN {print int($SCC_SIZE * $FULL / 100.0)}"); \
+    [ "${SCC_SIZE}" -eq 0 ] && SCC_SIZE=1; \
+    SCC_SIZE="${SCC_SIZE}m"; \
+    java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version; \
+    unset OPENJ9_JAVA_OPTIONS; \
+    \
+    export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal"; \
+    "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
+    sleep 5; \
+    "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh -force; \
+    sleep 5; \
+    FULL=$( (java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'); \
+    echo "SCC layer is $FULL% full."; \
+    rm -rf "${INSTALL_PATH_TOMCAT}"; \
+    # Create a new SCC layer
+    if [ ! -d "/opt/java/.scc" ]; then \
+          mkdir /opt/java/.scc; \
+    fi; \
+    chmod -R 0777 /opt/java/.scc; \
+    \
+    echo "SCC generation phase completed";
+
+CMD ["jshell"]

--- a/17-ea/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17-ea/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -1,0 +1,142 @@
+# (C) Copyright IBM Corporation 2022, 2023
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+# Artifactory credentials to download CRIU binary
+# Set your Artifactory credentials here or pass them at build time
+ARG ARTIFACTORY_TOKEN
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN dnf install -y \
+    # CRIU dependencies
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+    # Semeru dependencies
+        tzdata openssl curl ca-certificates fontconfig glibc-langpack-en gzip tar \
+    # other dependencies
+        python3 \
+    && dnf update -y; dnf clean all;
+
+LABEL name="IBM Semeru Runtime EA" \
+      vendor="International Business Machines Corporation" \
+      version="17.0.6.6" \
+      release="17" \
+      run="docker run --rm -ti <image_name:tag> /bin/bash" \
+      summary="IBM Semeru Runtime EA Docker Image for OpenJDK with openj9 and ubi" \
+      description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
+
+# Install CRIU
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    case "${ARCH}" in \
+       amd64|x86_64) \
+          CRIU_URL='https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/hyc-runtimes-jenkins.swg-devops.com/build-scripts/criu_build/3/criu.tar.gz'; \
+          CRIU_SHA_URL='https://na.artifactory.swg-devops.com/artifactory/sys-rt-generic-local/hyc-runtimes-jenkins.swg-devops.com/build-scripts/criu_build/3/criu.tar.gz.sha256.txt'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    cd /tmp; \
+    curl -H X-JFrog-Art-Api:${ARTIFACTORY_TOKEN} -LfsSo criu.tar.gz ${CRIU_URL};\
+    curl -H X-JFrog-Art-Api:${ARTIFACTORY_TOKEN} -LfsSo criu.tar.gz.sha256.txt ${CRIU_SHA_URL};\
+    sha256sum -c criu.tar.gz.sha256.txt; \
+    tar -xzf criu.tar.gz --strip-components=1; \
+    cp -R usr/local /usr; \
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/criu.conf; \
+    ldconfig; \
+    setcap cap_checkpoint_restore,cap_sys_ptrace=eip /usr/local/sbin/criu; \
+    rm -fr criu criu.tar.gz;
+
+ENV PATH="/usr/local/sbin:$PATH"
+
+ENV JAVA_VERSION 17.0.6.6
+
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    case "${ARCH}" in \
+       amd64|x86_64) \
+         ESUM='58c6d39dcb582a7924099a2cbc9210b809705456eaec72e807dbd4fa01190cae'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-ea-binaries/releases/download/jdk-17.0.6%2B6_december_22-preview_1/ibm-semeru-open-ea-jre_x64_linux_17.0.6_6_December_22-preview_1.tar.gz'; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/java/java-ea; \
+    cd /opt/java/java-ea; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1;
+
+ENV JAVA_HOME=/opt/java/java-ea \
+    PATH="/opt/java/java-ea/bin:$PATH"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+PortableSharedCache -XX:+IdleTuningGcOnIdle -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,readonly,nonFatal"
+
+# Create OpenJ9 SharedClassCache (SCC) for bootclasses to improve the java startup.
+# Downloads and runs tomcat to generate SCC for bootclasses at /opt/java/.scc/openj9_system_scc
+# Does a dry-run and calculates the optimal cache size and recreates the cache with the appropriate size.
+# With SCC, OpenJ9 startup is improved ~50% with an increase in image size of ~14MB
+# Application classes can be create a separate cache layer with this as the base for further startup improvement
+
+RUN set -eux; \
+    unset OPENJ9_JAVA_OPTIONS; \
+    SCC_SIZE="50m"; \
+    DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
+    INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
+    TOMCAT_CHECKSUM="0db27185d9fc3174f2c670f814df3dda8a008b89d1a38a5d96cbbe119767ebfb1cf0bce956b27954aee9be19c4a7b91f2579d967932207976322033a86075f98"; \
+    TOMCAT_DWNLD_URL="https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.35/bin/apache-tomcat-9.0.35.tar.gz"; \
+    \
+    mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
+    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
+    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
+    rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
+    \
+    java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version; \
+    export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal"; \
+    "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
+    sleep 5; \
+    "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh -force; \
+    sleep 15; \
+    FULL=$( (java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'); \
+    DST_CACHE=$(java -Xshareclasses:name=dry_run_scc,cacheDir=/opt/java/.scc,destroy 2>&1 || true); \
+    SCC_SIZE=$(echo $SCC_SIZE | sed 's/.$//'); \
+    SCC_SIZE=$(awk "BEGIN {print int($SCC_SIZE * $FULL / 100.0)}"); \
+    [ "${SCC_SIZE}" -eq 0 ] && SCC_SIZE=1; \
+    SCC_SIZE="${SCC_SIZE}m"; \
+    java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal,createLayer -Xscmx$SCC_SIZE -version; \
+    unset OPENJ9_JAVA_OPTIONS; \
+    \
+    export OPENJ9_JAVA_OPTIONS="-Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,bootClassesOnly,nonFatal"; \
+    "${INSTALL_PATH_TOMCAT}"/bin/startup.sh; \
+    sleep 5; \
+    "${INSTALL_PATH_TOMCAT}"/bin/shutdown.sh -force; \
+    sleep 5; \
+    FULL=$( (java -Xshareclasses:name=openj9_system_scc,cacheDir=/opt/java/.scc,printallStats 2>&1 || true) | awk '/^Cache is [0-9.]*% .*full/ {print substr($3, 1, length($3)-1)}'); \
+    echo "SCC layer is $FULL% full."; \
+    rm -rf "${INSTALL_PATH_TOMCAT}"; \
+    # Create a new SCC layer
+    if [ ! -d "/opt/java/.scc" ]; then \
+          mkdir /opt/java/.scc; \
+    fi; \
+    chmod -R 0777 /opt/java/.scc; \
+    \
+    echo "SCC generation phase completed";
+
+CMD ["jshell"]

--- a/criu/ubi8/Dockerfile
+++ b/criu/ubi8/Dockerfile
@@ -1,0 +1,111 @@
+# (C) Copyright IBM Corporation 2023, 2023
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+################################################################################
+# Requires FTP3 credentials for ftp3.linux.ibm.com
+# Set credentials here or at build time using --build-arg option,
+# e.g. docker build --build-arg FTP3_USER=<user name> --build-arg FTP3_PASSWORD=<password> -f Dockerfile .
+################################################################################
+
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+# Must have FTP3 account
+# Set your FTP3 credentials here or pass them at build time
+ARG FTP3_USER="YOUR FTP3 USER NAME"
+ARG FTP3_PASSWORD="YOUR PASSWORD"
+
+ARG CRIU_REPO=https://github.com/checkpoint-restore/criu.git
+ARG CRIU_BRANCH=criu-dev
+# Last stable commit SHA
+ARG CRIU_SHA=f7bcd1c8c32bd04df72dfac71ba8da3dbd36b245
+
+# Cherry pick fix to restoring SO_BUF_LOCK (from developer fork)
+ARG CRIU_FIX_REPO=https://github.com/ymanton/criu.git
+ARG CRIU_FIX_SHA=d46233dc7775539c275710e18733ed9b5aceb153
+
+# First compile criu required for checkpoint
+# CRIU dependencies
+RUN dnf install -y \
+    iptables-libs \
+    jansson \
+    libibverbs \
+    libcap \
+    libmnl \
+    libnet \
+    libnftnl \
+    libpcap \
+    nftables \
+    protobuf-c
+
+# Download script to install CRIU build dependencies
+RUN cd /tmp \
+    && curl -k -u ${FTP3_USER}:${FTP3_PASSWORD} -o ibm-yum.sh ftp://ftp3.linux.ibm.com/redhat/ibm-yum.sh \
+    && chmod a+x ibm-yum.sh
+
+# CRIU build dependencies
+
+RUN set -eux; \
+    export FTP3USER=${FTP3_USER} \
+    && export FTP3PASS=${FTP3_PASSWORD} \
+    && /tmp/ibm-yum.sh install -y \
+        glibc-locale-source \
+        kernel-devel \
+        make \
+        automake \
+        gcc \
+        gcc-c++ \
+        glibc \
+        vim \
+        git \
+        asciidoc \
+        gnutls-devel \
+        libcap-devel \
+        libnet-devel \
+        libnl3-devel \
+        nftables \
+        nftables-devel \
+        pkgconfig \
+        protobuf-c \
+        protobuf-c-devel \
+        protobuf-devel \
+        python3 \
+        python3-protobuf \
+        xmlto \
+    && unset FTP3PASS \
+    && unset FTP3USER \
+    && cd ../ \
+    && rm -f ibm-yum.sh
+
+RUN cd /tmp; \
+    git clone -b ${CRIU_BRANCH} ${CRIU_REPO}; \
+    mv criu criu-build; \
+    cd criu-build; \
+    git config --global user.email "build@example.com"; \
+    git config --global user.name "build"; \
+    if [ "x${CRIU_SHA}" == x ] ; then \
+        CRIU_SHA=$(git rev-parse HEAD); \
+    fi; \
+    git reset --hard ${CRIU_SHA}; \
+    if [ "x${CRIU_FIX_SHA}" != x ] ; then \
+        git remote add dev ${CRIU_FIX_REPO}; \
+        git fetch dev; \
+        git cherry-pick ${CRIU_FIX_SHA}; \
+    fi; \
+    make; \
+    make DESTDIR=/tmp/criu install-lib install-criu; \
+    cd ../; \
+    tar -czf criu.tar.gz criu; \
+    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt; \
+    rm -fr criu-build;


### PR DESCRIPTION
Add semeru-ea binaries

Add dockerfile to build criu from source.
Update dockerfiles for Semeru 17-ea:
  - install criu from binary

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>