### PR TITLE
Use different permissions for restore criu file

### DIFF
--- a/17-ea/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17-ea/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -60,6 +60,9 @@ RUN set -eux; \
     echo /usr/local/lib64 > /etc/ld.so.conf.d/criu.conf; \
     ldconfig; \
     setcap cap_checkpoint_restore,cap_sys_ptrace,cap_setpcap=eip /usr/local/sbin/criu; \
+    mkdir -p /opt/criu; \
+    cp /usr/local/sbin/criu /opt/criu/criu; \
+    setcap cap_checkpoint_restore,cap_setpcap=eip /opt/criu/criu; \
     rm -fr criu criu.tar.gz;
 
 ENV PATH="/usr/local/sbin:$PATH"

--- a/17-ea/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17-ea/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -60,6 +60,9 @@ RUN set -eux; \
     echo /usr/local/lib64 > /etc/ld.so.conf.d/criu.conf; \
     ldconfig; \
     setcap cap_checkpoint_restore,cap_sys_ptrace,cap_setpcap=eip /usr/local/sbin/criu; \
+    mkdir -p /opt/criu; \
+    cp /usr/local/sbin/criu /opt/criu/criu; \
+    setcap cap_checkpoint_restore,cap_setpcap=eip /opt/criu/criu; \
     rm -fr criu criu.tar.gz;
 
 ENV PATH="/usr/local/sbin:$PATH"


### PR DESCRIPTION
Use different permissions for restore criu file

The level of permissions required for criu differ between checkpoint
and restore. On restore fewer sys_ptrace is not needed. This PR makes a
copy of the CRIU CLI (/opt/criu/criu) app and sets different capabilites
in the restore version.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>