### PR TITLE
Update JDK11 and JDK17 release versions for Semeru CE, and

### DIFF
--- a/11/jdk/centos/Dockerfile.certified.releases.full
+++ b/11/jdk/centos/Dockerfile.certified.releases.full
@@ -20,22 +20,22 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='563d724aeedfb9e1afd1d3d37fd7bd7fd2873148204ed95f4a949c8e1add801a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_x64_linux_11.0.18.0-archive.bin'; \
+         ESUM='4f646a746b7956c977558ab181fe57d8239b33f44756f18087a1ff6c8c414e28'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_11.0.19.0-archive.bin'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9b15f172132812e1a210cc0765f14d32efbd60fd2b3267fc42dd8405712b2efb'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_ppc64le_linux_11.0.18.0-archive.bin'; \
+         ESUM='905e1e2eea6443b9e020a88073c57c89b7dffa695f6d1aa05cd93a246addaa7b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.19.0-archive.bin'; \
          ;; \
        s390x) \
-         ESUM='fcd9ff5fee7505a5d9b794ddb69fea2e79b99abda318d046e49c80255cfbf418'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_s390x_linux_11.0.18.0-archive.bin'; \
+         ESUM='c543fb0048b5d90e85828ccb6147cbdd2161a21ff46c3e1de9c6e10ad45eb77b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_11.0.19.0-archive.bin'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -22,28 +22,28 @@ RUN microdnf install -y tzdata openssl curl wget ca-certificates fontconfig glib
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.18.0" \
+      version="11.0.19.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Edition Docker Image for OpenJDK with openj9 and ubi-minimal" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='563d724aeedfb9e1afd1d3d37fd7bd7fd2873148204ed95f4a949c8e1add801a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_x64_linux_11.0.18.0-archive.bin'; \
+         ESUM='4f646a746b7956c977558ab181fe57d8239b33f44756f18087a1ff6c8c414e28'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_11.0.19.0-archive.bin'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9b15f172132812e1a210cc0765f14d32efbd60fd2b3267fc42dd8405712b2efb'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_ppc64le_linux_11.0.18.0-archive.bin'; \
+         ESUM='905e1e2eea6443b9e020a88073c57c89b7dffa695f6d1aa05cd93a246addaa7b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.19.0-archive.bin'; \
          ;; \
        s390x) \
-         ESUM='fcd9ff5fee7505a5d9b794ddb69fea2e79b99abda318d046e49c80255cfbf418'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_s390x_linux_11.0.18.0-archive.bin'; \
+         ESUM='c543fb0048b5d90e85828ccb6147cbdd2161a21ff46c3e1de9c6e10ad45eb77b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_11.0.19.0-archive.bin'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/11/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -117,3 +117,4 @@ RUN set -eux; \
     echo "SCC generation phase completed";
 
 CMD ["jshell"]
+USER 1001

--- a/11/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -22,28 +22,28 @@ RUN microdnf install -y tzdata openssl wget ca-certificates fontconfig glibc-lan
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.18.0" \
+      version="11.0.19.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Edition Docker Image for OpenJDK with openj9 and ubi-minimal" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='563d724aeedfb9e1afd1d3d37fd7bd7fd2873148204ed95f4a949c8e1add801a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_x64_linux_11.0.18.0-archive.bin'; \
+         ESUM='4f646a746b7956c977558ab181fe57d8239b33f44756f18087a1ff6c8c414e28'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_11.0.19.0-archive.bin'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9b15f172132812e1a210cc0765f14d32efbd60fd2b3267fc42dd8405712b2efb'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_ppc64le_linux_11.0.18.0-archive.bin'; \
+         ESUM='905e1e2eea6443b9e020a88073c57c89b7dffa695f6d1aa05cd93a246addaa7b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.19.0-archive.bin'; \
          ;; \
        s390x) \
-         ESUM='fcd9ff5fee7505a5d9b794ddb69fea2e79b99abda318d046e49c80255cfbf418'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_s390x_linux_11.0.18.0-archive.bin'; \
+         ESUM='c543fb0048b5d90e85828ccb6147cbdd2161a21ff46c3e1de9c6e10ad45eb77b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_11.0.19.0-archive.bin'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/11/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -117,3 +117,4 @@ RUN set -eux; \
     echo "SCC generation phase completed";
 
 CMD ["jshell"]
+USER 1001

--- a/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -25,28 +25,28 @@ RUN yum install -y tzdata openssl curl wget openssl ca-certificates fontconfig g
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.18.0" \
+      version="11.0.19.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Edition Docker Image for OpenJDK with openj9 and ubi" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='563d724aeedfb9e1afd1d3d37fd7bd7fd2873148204ed95f4a949c8e1add801a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_x64_linux_11.0.18.0-archive.bin'; \
+         ESUM='4f646a746b7956c977558ab181fe57d8239b33f44756f18087a1ff6c8c414e28'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_11.0.19.0-archive.bin'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9b15f172132812e1a210cc0765f14d32efbd60fd2b3267fc42dd8405712b2efb'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_ppc64le_linux_11.0.18.0-archive.bin'; \
+         ESUM='905e1e2eea6443b9e020a88073c57c89b7dffa695f6d1aa05cd93a246addaa7b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.19.0-archive.bin'; \
          ;; \
        s390x) \
-         ESUM='fcd9ff5fee7505a5d9b794ddb69fea2e79b99abda318d046e49c80255cfbf418'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_s390x_linux_11.0.18.0-archive.bin'; \
+         ESUM='c543fb0048b5d90e85828ccb6147cbdd2161a21ff46c3e1de9c6e10ad45eb77b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_11.0.19.0-archive.bin'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -168,3 +168,4 @@ RUN set -eux; \
     echo "SCC generation phase completed";
 
 CMD ["jshell"]
+USER 1001

--- a/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -25,28 +25,28 @@ RUN yum install -y tzdata openssl wget openssl ca-certificates fontconfig glibc-
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.18.0" \
+      version="11.0.19.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Edition Docker Image for OpenJDK with openj9 and ubi" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='563d724aeedfb9e1afd1d3d37fd7bd7fd2873148204ed95f4a949c8e1add801a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_x64_linux_11.0.18.0-archive.bin'; \
+         ESUM='4f646a746b7956c977558ab181fe57d8239b33f44756f18087a1ff6c8c414e28'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_11.0.19.0-archive.bin'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9b15f172132812e1a210cc0765f14d32efbd60fd2b3267fc42dd8405712b2efb'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_ppc64le_linux_11.0.18.0-archive.bin'; \
+         ESUM='905e1e2eea6443b9e020a88073c57c89b7dffa695f6d1aa05cd93a246addaa7b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.19.0-archive.bin'; \
          ;; \
        s390x) \
-         ESUM='fcd9ff5fee7505a5d9b794ddb69fea2e79b99abda318d046e49c80255cfbf418'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_s390x_linux_11.0.18.0-archive.bin'; \
+         ESUM='c543fb0048b5d90e85828ccb6147cbdd2161a21ff46c3e1de9c6e10ad45eb77b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_11.0.19.0-archive.bin'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -15,6 +15,10 @@
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
+# Artifactory credentials to download CRIU binary
+# Set your Artifactory credentials here or pass them at build time
+ARG ARTIFACTORY_TOKEN
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
@@ -160,3 +164,4 @@ RUN set -eux; \
     echo "SCC generation phase completed";
 
 CMD ["jshell"]
+USER 1001

--- a/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -22,22 +22,22 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='563d724aeedfb9e1afd1d3d37fd7bd7fd2873148204ed95f4a949c8e1add801a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_x64_linux_11.0.18.0-archive.bin'; \
+         ESUM='4f646a746b7956c977558ab181fe57d8239b33f44756f18087a1ff6c8c414e28'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_11.0.19.0-archive.bin'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9b15f172132812e1a210cc0765f14d32efbd60fd2b3267fc42dd8405712b2efb'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_ppc64le_linux_11.0.18.0-archive.bin'; \
+         ESUM='905e1e2eea6443b9e020a88073c57c89b7dffa695f6d1aa05cd93a246addaa7b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.19.0-archive.bin'; \
          ;; \
        s390x) \
-         ESUM='fcd9ff5fee7505a5d9b794ddb69fea2e79b99abda318d046e49c80255cfbf418'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_s390x_linux_11.0.18.0-archive.bin'; \
+         ESUM='c543fb0048b5d90e85828ccb6147cbdd2161a21ff46c3e1de9c6e10ad45eb77b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_11.0.19.0-archive.bin'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -22,22 +22,22 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='563d724aeedfb9e1afd1d3d37fd7bd7fd2873148204ed95f4a949c8e1add801a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_x64_linux_11.0.18.0-archive.bin'; \
+         ESUM='4f646a746b7956c977558ab181fe57d8239b33f44756f18087a1ff6c8c414e28'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_11.0.19.0-archive.bin'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='9b15f172132812e1a210cc0765f14d32efbd60fd2b3267fc42dd8405712b2efb'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_ppc64le_linux_11.0.18.0-archive.bin'; \
+         ESUM='905e1e2eea6443b9e020a88073c57c89b7dffa695f6d1aa05cd93a246addaa7b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.19.0-archive.bin'; \
          ;; \
        s390x) \
-         ESUM='fcd9ff5fee7505a5d9b794ddb69fea2e79b99abda318d046e49c80255cfbf418'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jdk_s390x_linux_11.0.18.0-archive.bin'; \
+         ESUM='c543fb0048b5d90e85828ccb6147cbdd2161a21ff46c3e1de9c6e10ad45eb77b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_11.0.19.0-archive.bin'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/centos/Dockerfile.certified.releases.full
+++ b/11/jre/centos/Dockerfile.certified.releases.full
@@ -20,22 +20,22 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='27bd5f2f8b10da1274485fd3c2d7aff25109e86cf234436fa2b7377dbfa21c9d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_x64_linux_11.0.18.0.tar.gz'; \
+         ESUM='1d344aca4a9d2cb6be1d6e6a324e29a9803456cdc964c48963b2f1b53bb251ed'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_11.0.19.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='dbe99a8e6b0e7891119011ac765e0de27bd6fa72a7ef03894780cd3f37d4bacd'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_ppc64le_linux_11.0.18.0.tar.gz'; \
+         ESUM='788496e440a7eae1b5234bcb1d1ca591a2c0ada946a93828e36615cf1e6269df'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.19.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='26d429438385e3fd0669884c22244c780d0d913821bf475da84625619f2d62b8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_s390x_linux_11.0.18.0.tar.gz'; \
+         ESUM='7a331c0e11c52dcdd2c56b21be864b061f1c1c650c790286073c6d4dc9b999e5'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_11.0.19.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -22,28 +22,28 @@ RUN microdnf install -y tzdata openssl curl wget ca-certificates fontconfig glib
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.18.0" \
+      version="11.0.19.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Edition Docker Image for OpenJDK with openj9 and ubi-minimal" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='27bd5f2f8b10da1274485fd3c2d7aff25109e86cf234436fa2b7377dbfa21c9d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_x64_linux_11.0.18.0.tar.gz'; \
+         ESUM='1d344aca4a9d2cb6be1d6e6a324e29a9803456cdc964c48963b2f1b53bb251ed'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_11.0.19.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='dbe99a8e6b0e7891119011ac765e0de27bd6fa72a7ef03894780cd3f37d4bacd'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_ppc64le_linux_11.0.18.0.tar.gz'; \
+         ESUM='788496e440a7eae1b5234bcb1d1ca591a2c0ada946a93828e36615cf1e6269df'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.19.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='26d429438385e3fd0669884c22244c780d0d913821bf475da84625619f2d62b8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_s390x_linux_11.0.18.0.tar.gz'; \
+         ESUM='7a331c0e11c52dcdd2c56b21be864b061f1c1c650c790286073c6d4dc9b999e5'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_11.0.19.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/11/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/11/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -22,28 +22,28 @@ RUN microdnf install -y tzdata openssl wget ca-certificates fontconfig glibc-lan
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.18.0" \
+      version="11.0.19.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Edition Docker Image for OpenJDK with openj9 and ubi-minimal" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='27bd5f2f8b10da1274485fd3c2d7aff25109e86cf234436fa2b7377dbfa21c9d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_x64_linux_11.0.18.0.tar.gz'; \
+         ESUM='1d344aca4a9d2cb6be1d6e6a324e29a9803456cdc964c48963b2f1b53bb251ed'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_11.0.19.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='dbe99a8e6b0e7891119011ac765e0de27bd6fa72a7ef03894780cd3f37d4bacd'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_ppc64le_linux_11.0.18.0.tar.gz'; \
+         ESUM='788496e440a7eae1b5234bcb1d1ca591a2c0ada946a93828e36615cf1e6269df'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.19.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='26d429438385e3fd0669884c22244c780d0d913821bf475da84625619f2d62b8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_s390x_linux_11.0.18.0.tar.gz'; \
+         ESUM='7a331c0e11c52dcdd2c56b21be864b061f1c1c650c790286073c6d4dc9b999e5'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_11.0.19.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/11/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -25,28 +25,28 @@ RUN yum install -y tzdata openssl curl wget openssl ca-certificates fontconfig g
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.18.0" \
+      version="11.0.19.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Edition Docker Image for OpenJDK with openj9 and ubi" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='27bd5f2f8b10da1274485fd3c2d7aff25109e86cf234436fa2b7377dbfa21c9d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_x64_linux_11.0.18.0.tar.gz'; \
+         ESUM='1d344aca4a9d2cb6be1d6e6a324e29a9803456cdc964c48963b2f1b53bb251ed'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_11.0.19.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='dbe99a8e6b0e7891119011ac765e0de27bd6fa72a7ef03894780cd3f37d4bacd'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_ppc64le_linux_11.0.18.0.tar.gz'; \
+         ESUM='788496e440a7eae1b5234bcb1d1ca591a2c0ada946a93828e36615cf1e6269df'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.19.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='26d429438385e3fd0669884c22244c780d0d913821bf475da84625619f2d62b8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_s390x_linux_11.0.18.0.tar.gz'; \
+         ESUM='7a331c0e11c52dcdd2c56b21be864b061f1c1c650c790286073c6d4dc9b999e5'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_11.0.19.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -30,7 +30,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Open Edition" \
       vendor="International Business Machines Corporation" \
-      version="jdk-11.0.18+10_openj9-0.36.0" \
+      version="jdk-11.0.19+7_openj9-0.38.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Docker Image for OpenJDK with openj9 and ubi" \
@@ -167,3 +167,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -25,28 +25,28 @@ RUN yum install -y tzdata openssl wget openssl ca-certificates fontconfig glibc-
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.18.0" \
+      version="11.0.19.0" \
       release="11" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Edition Docker Image for OpenJDK with openj9 and ubi" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='27bd5f2f8b10da1274485fd3c2d7aff25109e86cf234436fa2b7377dbfa21c9d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_x64_linux_11.0.18.0.tar.gz'; \
+         ESUM='1d344aca4a9d2cb6be1d6e6a324e29a9803456cdc964c48963b2f1b53bb251ed'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_11.0.19.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='dbe99a8e6b0e7891119011ac765e0de27bd6fa72a7ef03894780cd3f37d4bacd'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_ppc64le_linux_11.0.18.0.tar.gz'; \
+         ESUM='788496e440a7eae1b5234bcb1d1ca591a2c0ada946a93828e36615cf1e6269df'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.19.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='26d429438385e3fd0669884c22244c780d0d913821bf475da84625619f2d62b8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_s390x_linux_11.0.18.0.tar.gz'; \
+         ESUM='7a331c0e11c52dcdd2c56b21be864b061f1c1c650c790286073c6d4dc9b999e5'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_11.0.19.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -15,6 +15,10 @@
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
+# Artifactory credentials to download CRIU binary
+# Set your Artifactory credentials here or pass them at build time
+ARG ARTIFACTORY_TOKEN
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
@@ -159,3 +163,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD["jshell"]
+USER 1001

--- a/11/jre/ubuntu/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/Dockerfile.certified.releases.full
@@ -22,22 +22,22 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='27bd5f2f8b10da1274485fd3c2d7aff25109e86cf234436fa2b7377dbfa21c9d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_x64_linux_11.0.18.0.tar.gz'; \
+         ESUM='1d344aca4a9d2cb6be1d6e6a324e29a9803456cdc964c48963b2f1b53bb251ed'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_11.0.19.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='dbe99a8e6b0e7891119011ac765e0de27bd6fa72a7ef03894780cd3f37d4bacd'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_ppc64le_linux_11.0.18.0.tar.gz'; \
+         ESUM='788496e440a7eae1b5234bcb1d1ca591a2c0ada946a93828e36615cf1e6269df'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.19.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='26d429438385e3fd0669884c22244c780d0d913821bf475da84625619f2d62b8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_s390x_linux_11.0.18.0.tar.gz'; \
+         ESUM='7a331c0e11c52dcdd2c56b21be864b061f1c1c650c790286073c6d4dc9b999e5'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_11.0.19.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -22,22 +22,22 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='27bd5f2f8b10da1274485fd3c2d7aff25109e86cf234436fa2b7377dbfa21c9d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_x64_linux_11.0.18.0.tar.gz'; \
+         ESUM='1d344aca4a9d2cb6be1d6e6a324e29a9803456cdc964c48963b2f1b53bb251ed'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_11.0.19.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='dbe99a8e6b0e7891119011ac765e0de27bd6fa72a7ef03894780cd3f37d4bacd'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_ppc64le_linux_11.0.18.0.tar.gz'; \
+         ESUM='788496e440a7eae1b5234bcb1d1ca591a2c0ada946a93828e36615cf1e6269df'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.19.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='26d429438385e3fd0669884c22244c780d0d913821bf475da84625619f2d62b8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_s390x_linux_11.0.18.0.tar.gz'; \
+         ESUM='7a331c0e11c52dcdd2c56b21be864b061f1c1c650c790286073c6d4dc9b999e5'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_11.0.19.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -22,22 +22,22 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.18.0
+ENV JAVA_VERSION 11.0.19.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='27bd5f2f8b10da1274485fd3c2d7aff25109e86cf234436fa2b7377dbfa21c9d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_x64_linux_11.0.18.0.tar.gz'; \
+         ESUM='1d344aca4a9d2cb6be1d6e6a324e29a9803456cdc964c48963b2f1b53bb251ed'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_11.0.19.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='dbe99a8e6b0e7891119011ac765e0de27bd6fa72a7ef03894780cd3f37d4bacd'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_ppc64le_linux_11.0.18.0.tar.gz'; \
+         ESUM='788496e440a7eae1b5234bcb1d1ca591a2c0ada946a93828e36615cf1e6269df'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.19.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='26d429438385e3fd0669884c22244c780d0d913821bf475da84625619f2d62b8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.18%2B10_openj9-0.36.1/ibm-semeru-certified-jre_s390x_linux_11.0.18.0.tar.gz'; \
+         ESUM='7a331c0e11c52dcdd2c56b21be864b061f1c1c650c790286073c6d4dc9b999e5'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.19%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_11.0.19.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/centos/Dockerfile.certified.releases.full
+++ b/17/jdk/centos/Dockerfile.certified.releases.full
@@ -20,26 +20,26 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='656052010981d837eb24436b5fdb220aedc5729622aaa7f7f7660c8ffd961e4d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.6.0.tar.gz'; \
+         ESUM='a1c9ed36f803789871b6db4c202746a99dd514d6bf515287a83ba4644f6cb839'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.7.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='584627bcdf786113e46014a0ff9e20c03148b31729b9d6f9f13feea93ed137db'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='bcb22eef82e1ddad1e581c28b6aea5a163cdba7046001c36c242ffa336fb6439'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='2e3bf6f841e354da849228811802037b24026dcdf2d8c79277a60c3e0a88aecf'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='9e2d0be2da4b71783ed3bc6885341888ca3f7bdac2fb22b3579ce65304004646'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4335fa09c494bf87162826bd0f617475ccd10414eb0ff80c2208877881144457'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='a3130818bde474f6b1f9bcbb5e7f5dc5196639cac4190b6e26fbab6b428ecee9'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_17.0.7.0.tar.gz'; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -22,28 +22,32 @@ RUN microdnf install -y tzdata openssl curl ca-certificates fontconfig glibc-lan
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.6.0" \
+      version="17.0.7.0" \
       release="17" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Docker Image for OpenJDK with openj9 and ubi-minimal" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='a1c9ed36f803789871b6db4c202746a99dd514d6bf515287a83ba4644f6cb839'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='584627bcdf786113e46014a0ff9e20c03148b31729b9d6f9f13feea93ed137db'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='bcb22eef82e1ddad1e581c28b6aea5a163cdba7046001c36c242ffa336fb6439'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='2e3bf6f841e354da849228811802037b24026dcdf2d8c79277a60c3e0a88aecf'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='9e2d0be2da4b71783ed3bc6885341888ca3f7bdac2fb22b3579ce65304004646'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4335fa09c494bf87162826bd0f617475ccd10414eb0ff80c2208877881144457'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='a3130818bde474f6b1f9bcbb5e7f5dc5196639cac4190b6e26fbab6b428ecee9'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_17.0.7.0.tar.gz'; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/17/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -117,3 +117,4 @@ RUN set -eux; \
     echo "SCC generation phase completed";
 
 CMD ["jshell"]
+USER 1001

--- a/17/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -22,28 +22,32 @@ RUN microdnf install -y tzdata openssl ca-certificates fontconfig glibc-langpack
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.6.0" \
+      version="17.0.7.0" \
       release="17" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Docker Image for OpenJDK with openj9 and ubi-minimal" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='a1c9ed36f803789871b6db4c202746a99dd514d6bf515287a83ba4644f6cb839'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='584627bcdf786113e46014a0ff9e20c03148b31729b9d6f9f13feea93ed137db'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='bcb22eef82e1ddad1e581c28b6aea5a163cdba7046001c36c242ffa336fb6439'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='2e3bf6f841e354da849228811802037b24026dcdf2d8c79277a60c3e0a88aecf'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='9e2d0be2da4b71783ed3bc6885341888ca3f7bdac2fb22b3579ce65304004646'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4335fa09c494bf87162826bd0f617475ccd10414eb0ff80c2208877881144457'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='a3130818bde474f6b1f9bcbb5e7f5dc5196639cac4190b6e26fbab6b428ecee9'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_17.0.7.0.tar.gz'; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/17/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -117,3 +117,4 @@ RUN set -eux; \
     echo "SCC generation phase completed";
 
 CMD ["jshell"]
+USER 1001

--- a/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -22,28 +22,32 @@ RUN dnf install -y tzdata openssl curl ca-certificates fontconfig glibc-langpack
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.6.0" \
+      version="17.0.7.0" \
       release="17" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Docker Image for OpenJDK with openj9 and ubi" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='a1c9ed36f803789871b6db4c202746a99dd514d6bf515287a83ba4644f6cb839'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \ 
        amd64|x86_64) \
-         ESUM='584627bcdf786113e46014a0ff9e20c03148b31729b9d6f9f13feea93ed137db'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='bcb22eef82e1ddad1e581c28b6aea5a163cdba7046001c36c242ffa336fb6439'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='2e3bf6f841e354da849228811802037b24026dcdf2d8c79277a60c3e0a88aecf'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='9e2d0be2da4b71783ed3bc6885341888ca3f7bdac2fb22b3579ce65304004646'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4335fa09c494bf87162826bd0f617475ccd10414eb0ff80c2208877881144457'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='a3130818bde474f6b1f9bcbb5e7f5dc5196639cac4190b6e26fbab6b428ecee9'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_17.0.7.0.tar.gz'; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -168,3 +168,4 @@ RUN set -eux; \
     echo "SCC generation phase completed";
 
 CMD ["jshell"]
+USER 1001

--- a/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -22,28 +22,32 @@ RUN dnf install -y tzdata openssl ca-certificates fontconfig glibc-langpack-en g
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.6.0" \
+      version="17.0.7.0" \
       release="17" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Docker Image for OpenJDK with openj9 and ubi" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='a1c9ed36f803789871b6db4c202746a99dd514d6bf515287a83ba4644f6cb839'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='584627bcdf786113e46014a0ff9e20c03148b31729b9d6f9f13feea93ed137db'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='bcb22eef82e1ddad1e581c28b6aea5a163cdba7046001c36c242ffa336fb6439'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='2e3bf6f841e354da849228811802037b24026dcdf2d8c79277a60c3e0a88aecf'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='9e2d0be2da4b71783ed3bc6885341888ca3f7bdac2fb22b3579ce65304004646'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4335fa09c494bf87162826bd0f617475ccd10414eb0ff80c2208877881144457'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='a3130818bde474f6b1f9bcbb5e7f5dc5196639cac4190b6e26fbab6b428ecee9'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_17.0.7.0.tar.gz'; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -15,6 +15,10 @@
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
+# Artifactory credentials to download CRIU binary
+# Set your Artifactory credentials here or pass them at build time
+ARG ARTIFACTORY_TOKEN
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
@@ -160,3 +164,4 @@ RUN set -eux; \
     echo "SCC generation phase completed";
 
 CMD ["jshell"]
+USER 1001

--- a/17/jdk/ubuntu/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='656052010981d837eb24436b5fdb220aedc5729622aaa7f7f7660c8ffd961e4d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.6.0.tar.gz'; \
+         ESUM='a1c9ed36f803789871b6db4c202746a99dd514d6bf515287a83ba4644f6cb839'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.7.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='584627bcdf786113e46014a0ff9e20c03148b31729b9d6f9f13feea93ed137db'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='bcb22eef82e1ddad1e581c28b6aea5a163cdba7046001c36c242ffa336fb6439'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='2e3bf6f841e354da849228811802037b24026dcdf2d8c79277a60c3e0a88aecf'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='9e2d0be2da4b71783ed3bc6885341888ca3f7bdac2fb22b3579ce65304004646'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4335fa09c494bf87162826bd0f617475ccd10414eb0ff80c2208877881144457'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='a3130818bde474f6b1f9bcbb5e7f5dc5196639cac4190b6e26fbab6b428ecee9'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_17.0.7.0.tar.gz'; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='656052010981d837eb24436b5fdb220aedc5729622aaa7f7f7660c8ffd961e4d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.6.0.tar.gz'; \
+         ESUM='a1c9ed36f803789871b6db4c202746a99dd514d6bf515287a83ba4644f6cb839'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.7.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='584627bcdf786113e46014a0ff9e20c03148b31729b9d6f9f13feea93ed137db'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='bcb22eef82e1ddad1e581c28b6aea5a163cdba7046001c36c242ffa336fb6439'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='2e3bf6f841e354da849228811802037b24026dcdf2d8c79277a60c3e0a88aecf'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='9e2d0be2da4b71783ed3bc6885341888ca3f7bdac2fb22b3579ce65304004646'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4335fa09c494bf87162826bd0f617475ccd10414eb0ff80c2208877881144457'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='a3130818bde474f6b1f9bcbb5e7f5dc5196639cac4190b6e26fbab6b428ecee9'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_17.0.7.0.tar.gz'; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='656052010981d837eb24436b5fdb220aedc5729622aaa7f7f7660c8ffd961e4d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.6.0.tar.gz'; \
+         ESUM='a1c9ed36f803789871b6db4c202746a99dd514d6bf515287a83ba4644f6cb839'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.7.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='584627bcdf786113e46014a0ff9e20c03148b31729b9d6f9f13feea93ed137db'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='bcb22eef82e1ddad1e581c28b6aea5a163cdba7046001c36c242ffa336fb6439'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='2e3bf6f841e354da849228811802037b24026dcdf2d8c79277a60c3e0a88aecf'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='9e2d0be2da4b71783ed3bc6885341888ca3f7bdac2fb22b3579ce65304004646'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='4335fa09c494bf87162826bd0f617475ccd10414eb0ff80c2208877881144457'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jdk_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='a3130818bde474f6b1f9bcbb5e7f5dc5196639cac4190b6e26fbab6b428ecee9'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jdk_s390x_linux_17.0.7.0.tar.gz'; \
          ;;\
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/centos/Dockerfile.certified.releases.full
+++ b/17/jre/centos/Dockerfile.certified.releases.full
@@ -20,26 +20,26 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6e71b79ad175df2298a088aad7a2f14d8b2c9538096b3624669eaa214c460f42'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_aarch64_linux_17.0.6.0.tar.gz'; \
-         ;; \ 
+         ESUM='b11028f5d117b8df26ea7ff69d9d35e32fe9a492d37fccf8e122f9c3b10047cb'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='2f8421ab7cc6fd0d13580423be0b713749225c5a248c1eb6cc7009826030eb77'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='edc33d56378f9eab3676729f4bea087e0cb1f67596de6155fe127bf11b749b82'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='d86fac5f599e5943c2f423ce6d63b4f4f11e4d62a5558e31f6720dedb11eef1c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='b06f2ffd45597424ab8e056024b40e73b20ecd63ef30379b38140c371597fa2e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='75bc87a91dd5813774a26b31a8d9858c79d2cc73d8399f9889c4104c6acefae8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='7bd91b16f7ee05a2c1d9d955f0bc07d4f3398ffed43e05250cec991681909cb6'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_17.0.7.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -22,28 +22,32 @@ RUN microdnf install -y tzdata openssl curl ca-certificates fontconfig glibc-lan
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.6.0" \
+      version="17.0.7.0" \
       release="17" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Docker Image for OpenJDK with openj9 and ubi-minimal" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='b11028f5d117b8df26ea7ff69d9d35e32fe9a492d37fccf8e122f9c3b10047cb'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='2f8421ab7cc6fd0d13580423be0b713749225c5a248c1eb6cc7009826030eb77'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='edc33d56378f9eab3676729f4bea087e0cb1f67596de6155fe127bf11b749b82'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='d86fac5f599e5943c2f423ce6d63b4f4f11e4d62a5558e31f6720dedb11eef1c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='b06f2ffd45597424ab8e056024b40e73b20ecd63ef30379b38140c371597fa2e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='75bc87a91dd5813774a26b31a8d9858c79d2cc73d8399f9889c4104c6acefae8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='7bd91b16f7ee05a2c1d9d955f0bc07d4f3398ffed43e05250cec991681909cb6'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_17.0.7.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/17/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/17/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -22,28 +22,32 @@ RUN microdnf install -y tzdata openssl ca-certificates fontconfig glibc-langpack
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.6.0" \
+      version="17.0.7.0" \
       release="17" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Docker Image for OpenJDK with openj9 and ubi-minimal" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='b11028f5d117b8df26ea7ff69d9d35e32fe9a492d37fccf8e122f9c3b10047cb'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='2f8421ab7cc6fd0d13580423be0b713749225c5a248c1eb6cc7009826030eb77'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='edc33d56378f9eab3676729f4bea087e0cb1f67596de6155fe127bf11b749b82'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='d86fac5f599e5943c2f423ce6d63b4f4f11e4d62a5558e31f6720dedb11eef1c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='b06f2ffd45597424ab8e056024b40e73b20ecd63ef30379b38140c371597fa2e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='75bc87a91dd5813774a26b31a8d9858c79d2cc73d8399f9889c4104c6acefae8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='7bd91b16f7ee05a2c1d9d955f0bc07d4f3398ffed43e05250cec991681909cb6'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_17.0.7.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/17/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -22,28 +22,32 @@ RUN dnf install -y tzdata openssl curl ca-certificates fontconfig glibc-langpack
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.6.0" \
+      version="17.0.7.0" \
       release="17" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Docker Image for OpenJDK with openj9 and ubi" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='b11028f5d117b8df26ea7ff69d9d35e32fe9a492d37fccf8e122f9c3b10047cb'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='2f8421ab7cc6fd0d13580423be0b713749225c5a248c1eb6cc7009826030eb77'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='edc33d56378f9eab3676729f4bea087e0cb1f67596de6155fe127bf11b749b82'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='d86fac5f599e5943c2f423ce6d63b4f4f11e4d62a5558e31f6720dedb11eef1c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='b06f2ffd45597424ab8e056024b40e73b20ecd63ef30379b38140c371597fa2e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='75bc87a91dd5813774a26b31a8d9858c79d2cc73d8399f9889c4104c6acefae8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='7bd91b16f7ee05a2c1d9d955f0bc07d4f3398ffed43e05250cec991681909cb6'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_17.0.7.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -167,3 +167,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -22,28 +22,32 @@ RUN dnf install -y tzdata openssl ca-certificates fontconfig glibc-langpack-en g
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.6.0" \
+      version="17.0.7.0" \
       release="17" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
       summary="IBM Semeru Runtime Certified Docker Image for OpenJDK with openj9 and ubi" \
       description="For more information on this image please see https://github.com/ibmruntimes/semeru-containers/blob/master/README.md"
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='b11028f5d117b8df26ea7ff69d9d35e32fe9a492d37fccf8e122f9c3b10047cb'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='2f8421ab7cc6fd0d13580423be0b713749225c5a248c1eb6cc7009826030eb77'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='edc33d56378f9eab3676729f4bea087e0cb1f67596de6155fe127bf11b749b82'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='d86fac5f599e5943c2f423ce6d63b4f4f11e4d62a5558e31f6720dedb11eef1c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='b06f2ffd45597424ab8e056024b40e73b20ecd63ef30379b38140c371597fa2e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='75bc87a91dd5813774a26b31a8d9858c79d2cc73d8399f9889c4104c6acefae8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='7bd91b16f7ee05a2c1d9d955f0bc07d4f3398ffed43e05250cec991681909cb6'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_17.0.7.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -15,6 +15,10 @@
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
+# Artifactory credentials to download CRIU binary
+# Set your Artifactory credentials here or pass them at build time
+ARG ARTIFACTORY_TOKEN
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
@@ -159,3 +163,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/17/jre/ubuntu/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6e71b79ad175df2298a088aad7a2f14d8b2c9538096b3624669eaa214c460f42'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_aarch64_linux_17.0.6.0.tar.gz'; \
-         ;; \ 
+         ESUM='b11028f5d117b8df26ea7ff69d9d35e32fe9a492d37fccf8e122f9c3b10047cb'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='2f8421ab7cc6fd0d13580423be0b713749225c5a248c1eb6cc7009826030eb77'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='edc33d56378f9eab3676729f4bea087e0cb1f67596de6155fe127bf11b749b82'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='d86fac5f599e5943c2f423ce6d63b4f4f11e4d62a5558e31f6720dedb11eef1c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='b06f2ffd45597424ab8e056024b40e73b20ecd63ef30379b38140c371597fa2e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='75bc87a91dd5813774a26b31a8d9858c79d2cc73d8399f9889c4104c6acefae8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='7bd91b16f7ee05a2c1d9d955f0bc07d4f3398ffed43e05250cec991681909cb6'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_17.0.7.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6e71b79ad175df2298a088aad7a2f14d8b2c9538096b3624669eaa214c460f42'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_aarch64_linux_17.0.6.0.tar.gz'; \
+         ESUM='b11028f5d117b8df26ea7ff69d9d35e32fe9a492d37fccf8e122f9c3b10047cb'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_aarch64_linux_17.0.7.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='2f8421ab7cc6fd0d13580423be0b713749225c5a248c1eb6cc7009826030eb77'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='edc33d56378f9eab3676729f4bea087e0cb1f67596de6155fe127bf11b749b82'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='d86fac5f599e5943c2f423ce6d63b4f4f11e4d62a5558e31f6720dedb11eef1c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='b06f2ffd45597424ab8e056024b40e73b20ecd63ef30379b38140c371597fa2e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='75bc87a91dd5813774a26b31a8d9858c79d2cc73d8399f9889c4104c6acefae8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='7bd91b16f7ee05a2c1d9d955f0bc07d4f3398ffed43e05250cec991681909cb6'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_17.0.7.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.6.0
+ENV JAVA_VERSION 17.0.7.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6e71b79ad175df2298a088aad7a2f14d8b2c9538096b3624669eaa214c460f42'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_aarch64_linux_17.0.6.0.tar.gz'; \
-         ;; \ 
+         ESUM='b11028f5d117b8df26ea7ff69d9d35e32fe9a492d37fccf8e122f9c3b10047cb'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_aarch64_linux_17.0.7.0.tar.gz'; \
+         ;; \
        amd64|x86_64) \
-         ESUM='2f8421ab7cc6fd0d13580423be0b713749225c5a248c1eb6cc7009826030eb77'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_x64_linux_17.0.6.0.tar.gz'; \
+         ESUM='edc33d56378f9eab3676729f4bea087e0cb1f67596de6155fe127bf11b749b82'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_x64_linux_17.0.7.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='d86fac5f599e5943c2f423ce6d63b4f4f11e4d62a5558e31f6720dedb11eef1c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.6.0.tar.gz'; \
+         ESUM='b06f2ffd45597424ab8e056024b40e73b20ecd63ef30379b38140c371597fa2e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.7.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='75bc87a91dd5813774a26b31a8d9858c79d2cc73d8399f9889c4104c6acefae8'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.6%2B10_openj9-0.36.0/ibm-semeru-certified-jre_s390x_linux_17.0.6.0.tar.gz'; \
+         ESUM='7bd91b16f7ee05a2c1d9d955f0bc07d4f3398ffed43e05250cec991681909cb6'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.7%2B7_openj9-0.38.0/ibm-semeru-certified-jre_s390x_linux_17.0.7.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/8/jdk/ubi-minimal/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jdk/ubi/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jdk/ubuntu/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.open.releases.full
@@ -108,4 +108,3 @@ RUN set -eux; \
     fi; \
     \
     echo "SCC generation phase completed";
-

--- a/8/jre/ubi-minimal/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jre/ubi/Dockerfile.open.releases.full
+++ b/8/jre/ubi/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/8/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001

--- a/8/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/8/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -116,3 +116,5 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+CMD ["jshell"]
+USER 1001


### PR DESCRIPTION
also support non-root user installation for UBI images.