### PR TITLE
Generate /etc/instanton.ld.so.cache

### DIFF
--- a/11-ea/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11-ea/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -152,4 +152,18 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]

--- a/11-ea/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11-ea/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -152,4 +152,18 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]

--- a/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -177,5 +177,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/11/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -168,5 +168,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -178,5 +178,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/11/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -170,5 +170,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -166,5 +166,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/11/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -168,6 +168,20 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 
 USER 1001

--- a/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -166,5 +166,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/11/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -167,6 +167,20 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 
 USER 1001

--- a/17-ea/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17-ea/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -154,4 +154,18 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]

--- a/17-ea/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17-ea/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -154,4 +154,18 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]

--- a/17-ea/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17-ea/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -149,4 +149,18 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]

--- a/17-ea/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17-ea/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -149,4 +149,18 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]

--- a/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -168,5 +168,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/17/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -168,5 +168,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -168,5 +168,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/17/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -167,5 +167,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -168,5 +168,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/17/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -168,6 +168,20 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 
 USER 1001

--- a/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -168,5 +168,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/17/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -167,6 +167,20 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 
 USER 1001

--- a/20/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/20/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -167,5 +167,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/20/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/20/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -167,5 +167,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/20/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/20/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -167,5 +167,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/20/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/20/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -167,5 +167,19 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]
 USER 1001

--- a/21-ea/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/21-ea/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -154,4 +154,18 @@ RUN set -eux; \
     \
     echo "SCC generation phase completed";
 
+# For InstantOn, generate instanton.ld.so.cache which excludes glibc-hwcaps directories.
+# ldconfig output example lines:
+#         libcap-ng.so.0 (libc6,64bit) => /lib64/libcap-ng.so.0
+#         libc_malloc_debug.so.0 (libc6,64bit, OS ABI: Linux 3.10.0) => /lib64/libc_malloc_debug.so.0
+#         libc.so.6 (libc6,64bit, hwcap: "power10", OS ABI: Linux 3.10.0) => /lib64/glibc-hwcaps/power10/libc.so.6
+# sed regexp filter should pass any line that looks as follows: ... => /.../glibc-hwcaps/...
+RUN glibc_hwcaps_dirs=$(ldconfig --print-cache | sed --regexp-extended --silent 's,^.+[[:space:]]+=>[[:space:]]+(/.+/glibc-hwcaps)/.+$,\1,p' | sort | uniq) \
+    && mv -v /etc/ld.so.cache /etc/ld.so.cache.orig \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d $d-hidden; done \
+    && ldconfig \
+    && mv -v /etc/ld.so.cache /etc/instanton.ld.so.cache \
+    && for d in $glibc_hwcaps_dirs; do mv -v $d-hidden $d; done \
+    && mv -v /etc/ld.so.cache.orig /etc/ld.so.cache
+
 CMD ["jshell"]


### PR DESCRIPTION
This cache can be used by downstream images that want to include checkpointed processes by overwriting the default /etc/ld.so.cache prior to starting a process that will be checkpointed.

This cache excludes any previously cached libraries that are located under a directory named glibc-hwcaps. This directory contains processor-specific libraries that, when loaded, make it unlikely that a checkpointed process can be restored on an older (and probably incompatible) processor.