### PR TITLE
Update verify.sh

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -26,6 +26,9 @@
 image=$1
 arch=`echo $image | cut -d "/" -f1`
 
+# Get the current script's directory
+script_dir=$(dirname "$0")
+
 if [ "$arch" == "i386" ]; then
 	tag=$arch-`echo $image | cut -d ":" -f2`
 else
@@ -50,8 +53,8 @@ testJavaVersion()
 
 testHelloWorld()
 {
-   helloOutput=$(docker run --rm -v $PWD/hw:/opt/app $image java -jar /opt/app/hello.jar)
-   comparison=$(diff -u <(echo "$helloOutput") "$PWD/hw/hello.txt")
+   helloOutput=$(docker run --rm -v $script_dir/hw:/opt/app $image java -jar /opt/app/hello.jar)
+   comparison=$(diff -u <(echo "$helloOutput") "$script_dir/hw/hello.txt")
 
    if [ $? != 0 ]
    then


### PR DESCRIPTION
I've included the _script_dir_ variable in the script.

When we use _$PWD_, it simply gives us the present working directory. The previous script functions well when executed from the same location as the script itself.

However, when running the script from different locations, we face difficulties in accessing other scripts referenced within it. Therefore, _script_dir_ provides the path from the present working directory to the location of the script, helping resolve this issue.