### PR TITLE
Update Semeru UBI8 Dockerfile for license inclusion.

### DIFF
--- a/21/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/21/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -105,6 +105,9 @@ RUN set -eux; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
     tar -xf /tmp/openjdk.tar.gz --strip-components=1;
+    mkdir -p /licenses; \
+    cp /opt/java/openjdk/legal/java.base/LICENSE /licenses; \
+    rm -rf /tmp/openjdk.tar.gz;
 
 ENV JAVA_HOME=/opt/java/openjdk \
     PATH="/opt/java/openjdk/bin:$PATH"


### PR DESCRIPTION
Semeru 21 ubi8 dockerfile was missing steps to create license folder inside the docker container which blocks the publish of ubi image in Redhat repo. This update also ensures the Dockerfiles are in sync with that of other variants of ubi8.

<img width="584" alt="image" src="https://github.com/user-attachments/assets/362c001e-656e-4102-9b96-168fd563f03b">
