### PR TITLE
Update 21 jre ubi with missing line escape.

### DIFF
--- a/21/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/21/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -104,7 +104,7 @@ RUN set -eux; \
     echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
-    tar -xf /tmp/openjdk.tar.gz --strip-components=1;
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
     mkdir -p /licenses; \
     cp /opt/java/openjdk/legal/java.base/LICENSE /licenses; \
     rm -rf /tmp/openjdk.tar.gz;


### PR DESCRIPTION
Missed a Back slash at the end of line 107 in the previous PR  https://github.com/ibmruntimes/semeru-containers/pull/117 fixed it.