### PR TITLE
Add REGISTRY ARG for ubuntu dockerfiles

### DIFF
--- a/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update \

--- a/11/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update \

--- a/11/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update \

--- a/11/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update \

--- a/11/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update \

--- a/11/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/11/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -13,7 +13,10 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update \

--- a/11/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/11/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/17/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/17/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/17/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/21/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/21/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/21/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/21/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/21/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/21/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/21/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/23/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/23/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/23/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/23/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/23/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/23/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/23/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/23/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/23/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/23/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/23/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/23/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:20.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:20.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:22.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:22.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/8/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -13,7 +13,9 @@
 # limitations under the License.
 #
 
-FROM ubuntu:24.04
+ARG REGISTRY=docker.io
+BASE_IMAGE=ubuntu:24.04
+FROM ${REGISTRY}/${BASE_IMAGE}
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 


### PR DESCRIPTION
Due to change in Docker subscription model, It imposes restriction to access Dockerhub. 
Alternate sources for ubuntu image is public.ecr.aws/lts/ubuntu. 

In order to continue the publish on Dockerhub, the base image repository has to be passed as an argument, So dockerhub can build image based on official repo and Semeru container images built by team can use Amazon as base repo. 

More Info : https://github.ibm.com/runtimes/automation/issues/73