### PR TITLE
Add fallback to archive.apache.org for Tomcat download

### DIFF
--- a/11/jdk/centos/Dockerfile.certified.releases.full
+++ b/11/jdk/centos/Dockerfile.certified.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/centos/Dockerfile.open.releases.full
+++ b/11/jdk/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/11/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/11/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -140,11 +140,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -141,11 +141,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -135,11 +135,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -74,11 +74,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -74,11 +74,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -74,11 +74,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/centos/Dockerfile.certified.releases.full
+++ b/11/jre/centos/Dockerfile.certified.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/centos/Dockerfile.open.releases.full
+++ b/11/jre/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -134,11 +134,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/11/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -134,11 +134,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/11/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -135,11 +135,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -135,11 +135,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -74,11 +74,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -74,11 +74,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -74,11 +74,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/11/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/11/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/centos/Dockerfile.certified.releases.full
+++ b/17/jdk/centos/Dockerfile.certified.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/centos/Dockerfile.open.releases.full
+++ b/17/jdk/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/17/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/17/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -73,11 +73,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/17/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/centos/Dockerfile.certified.releases.full
+++ b/17/jre/centos/Dockerfile.certified.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/centos/Dockerfile.open.releases.full
+++ b/17/jre/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/17/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/17/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/17/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/17/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/centos/Dockerfile.certified.releases.full
+++ b/21/jdk/centos/Dockerfile.certified.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/centos/Dockerfile.open.releases.full
+++ b/21/jdk/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -134,11 +134,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/21/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -129,11 +129,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/21/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -128,11 +128,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -134,11 +134,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/21/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -128,11 +128,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/21/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -127,11 +127,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/21/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/21/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/21/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/centos/Dockerfile.certified.releases.full
+++ b/21/jre/centos/Dockerfile.certified.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/centos/Dockerfile.open.releases.full
+++ b/21/jre/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/21/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -134,11 +134,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/21/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/21/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -134,11 +134,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/21/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -133,11 +133,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/21/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -127,11 +127,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/21/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -126,11 +126,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/21/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -127,11 +127,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/21/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -126,11 +126,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/21/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/21/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -75,11 +75,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/21/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/21/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jdk/centos/Dockerfile.open.releases.full
+++ b/23/jdk/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/23/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/23/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -127,11 +127,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/23/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/23/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -126,11 +126,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/23/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/23/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/23/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jre/centos/Dockerfile.open.releases.full
+++ b/23/jre/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/23/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/23/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -132,11 +132,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/23/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -125,11 +125,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/23/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -125,11 +125,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/23/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/23/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/23/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/23/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/centos/Dockerfile.open.releases.full
+++ b/8/jdk/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubi-minimal/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/Dockerfile.open.releases.full
@@ -80,11 +80,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -80,11 +80,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -80,11 +80,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubi/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/Dockerfile.open.releases.full
@@ -79,11 +79,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -80,11 +80,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -80,11 +80,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubuntu/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.open.releases.full
@@ -68,11 +68,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -73,11 +73,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/centos/Dockerfile.open.releases.full
+++ b/8/jre/centos/Dockerfile.open.releases.full
@@ -69,11 +69,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubi-minimal/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/Dockerfile.open.releases.full
@@ -79,11 +79,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -80,11 +80,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -80,11 +80,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubi/Dockerfile.open.releases.full
+++ b/8/jre/ubi/Dockerfile.open.releases.full
@@ -79,11 +79,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/8/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -76,11 +76,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/8/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -80,11 +80,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubuntu/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \

--- a/8/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -72,11 +72,22 @@ RUN set -eux; \
     DOWNLOAD_PATH_TOMCAT=/tmp/tomcat; \
     INSTALL_PATH_TOMCAT=/opt/tomcat-home; \
     TOMCAT_CHECKSUM="904f10378ee2c7c68529edfefcba50c77eb677aa4586cfac0603e44703b0278f71f683b0295774f3cdcb027229d146490ef2c8868d8c2b5a631cf3db61ff9956"; \
-    TOMCAT_DWNLD_URL="https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.105/bin/apache-tomcat-9.0.105.tar.gz"; \
+    TOMCAT_VERSION="9.0.105"; \
+    TOMCAT_FILENAME="apache-tomcat-${TOMCAT_VERSION}.tar.gz"; \
+    SUCCESS=; \
     \
     mkdir -p "${DOWNLOAD_PATH_TOMCAT}" "${INSTALL_PATH_TOMCAT}"; \
-    curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${TOMCAT_DWNLD_URL}"; \
-    echo "${TOMCAT_CHECKSUM} *${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
+    for baseUrl in \
+        https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+        https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin \
+    ; do \
+        if curl -LfsSo "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz "${baseUrl}/${TOMCAT_FILENAME}" && [ -s "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz ]; then \
+            SUCCESS=1; \
+            break; \
+        fi; \
+    done; \
+    [ -n "$SUCCESS" ]; \
+    echo "${TOMCAT_CHECKSUM}  ${DOWNLOAD_PATH_TOMCAT}/tomcat.tar.gz" | sha512sum -c -; \
     tar -xf "${DOWNLOAD_PATH_TOMCAT}"/tomcat.tar.gz -C "${INSTALL_PATH_TOMCAT}" --strip-components=1; \
     rm -rf "${DOWNLOAD_PATH_TOMCAT}"; \
     \


### PR DESCRIPTION
Add fallback to archive.apache.org if tomcat version mentioned in Dockerfile not found on dlcdn.apache.org.