### PR TITLE
Updated Semeru CE releases 11,17,21 to latest versions

### DIFF
--- a/11/jdk/centos/Dockerfile.certified.releases.full
+++ b/11/jdk/centos/Dockerfile.certified.releases.full
@@ -20,26 +20,26 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='feef1adabd6624ea320b40e348b4e763f311cdc126a6af9d09e91c464bf317c3'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='8a706ac4be656fcba0b0bf6b8f055498adf4f12394380b2f6071ac1c0713bb0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='ce79aabc37c461f189765106e9a4a1f7defb4b89694514aaee6e8f6dbf604177'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='9c9a46c62a6e80db6d1a387cc0be50b85e19c8eefa52f74f9e56615bb050e475'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='ce1a18f62a4e08e0f4149514df08bb133acd220c542d3dfc99bf2d4bc8a5f47a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='7b203aa779f36946875f293b728d29cec334a7a155e6d98aed1b7cfb1f1bc8b8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='c1819feee7de0450af8da1be6ec6ad79c5f096fc01739fd64e4d881973b347da'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='c6a2faa2562228961ae3e78859a855e90e0b325b6e35a4e064f2f4fe5e0026d0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='feef1adabd6624ea320b40e348b4e763f311cdc126a6af9d09e91c464bf317c3'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='8a706ac4be656fcba0b0bf6b8f055498adf4f12394380b2f6071ac1c0713bb0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='ce79aabc37c461f189765106e9a4a1f7defb4b89694514aaee6e8f6dbf604177'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='9c9a46c62a6e80db6d1a387cc0be50b85e19c8eefa52f74f9e56615bb050e475'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='ce1a18f62a4e08e0f4149514df08bb133acd220c542d3dfc99bf2d4bc8a5f47a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='7b203aa779f36946875f293b728d29cec334a7a155e6d98aed1b7cfb1f1bc8b8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='c1819feee7de0450af8da1be6ec6ad79c5f096fc01739fd64e4d881973b347da'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='c6a2faa2562228961ae3e78859a855e90e0b325b6e35a4e064f2f4fe5e0026d0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='feef1adabd6624ea320b40e348b4e763f311cdc126a6af9d09e91c464bf317c3'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='8a706ac4be656fcba0b0bf6b8f055498adf4f12394380b2f6071ac1c0713bb0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='ce79aabc37c461f189765106e9a4a1f7defb4b89694514aaee6e8f6dbf604177'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='9c9a46c62a6e80db6d1a387cc0be50b85e19c8eefa52f74f9e56615bb050e475'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='ce1a18f62a4e08e0f4149514df08bb133acd220c542d3dfc99bf2d4bc8a5f47a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='7b203aa779f36946875f293b728d29cec334a7a155e6d98aed1b7cfb1f1bc8b8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='c1819feee7de0450af8da1be6ec6ad79c5f096fc01739fd64e4d881973b347da'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='c6a2faa2562228961ae3e78859a855e90e0b325b6e35a4e064f2f4fe5e0026d0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -87,26 +87,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='feef1adabd6624ea320b40e348b4e763f311cdc126a6af9d09e91c464bf317c3'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='8a706ac4be656fcba0b0bf6b8f055498adf4f12394380b2f6071ac1c0713bb0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='ce79aabc37c461f189765106e9a4a1f7defb4b89694514aaee6e8f6dbf604177'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='9c9a46c62a6e80db6d1a387cc0be50b85e19c8eefa52f74f9e56615bb050e475'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='ce1a18f62a4e08e0f4149514df08bb133acd220c542d3dfc99bf2d4bc8a5f47a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='7b203aa779f36946875f293b728d29cec334a7a155e6d98aed1b7cfb1f1bc8b8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='c1819feee7de0450af8da1be6ec6ad79c5f096fc01739fd64e4d881973b347da'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='c6a2faa2562228961ae3e78859a855e90e0b325b6e35a4e064f2f4fe5e0026d0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -88,26 +88,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='feef1adabd6624ea320b40e348b4e763f311cdc126a6af9d09e91c464bf317c3'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='8a706ac4be656fcba0b0bf6b8f055498adf4f12394380b2f6071ac1c0713bb0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='ce79aabc37c461f189765106e9a4a1f7defb4b89694514aaee6e8f6dbf604177'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='9c9a46c62a6e80db6d1a387cc0be50b85e19c8eefa52f74f9e56615bb050e475'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='ce1a18f62a4e08e0f4149514df08bb133acd220c542d3dfc99bf2d4bc8a5f47a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='7b203aa779f36946875f293b728d29cec334a7a155e6d98aed1b7cfb1f1bc8b8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='c1819feee7de0450af8da1be6ec6ad79c5f096fc01739fd64e4d881973b347da'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='c6a2faa2562228961ae3e78859a855e90e0b325b6e35a4e064f2f4fe5e0026d0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -22,26 +22,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='feef1adabd6624ea320b40e348b4e763f311cdc126a6af9d09e91c464bf317c3'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='8a706ac4be656fcba0b0bf6b8f055498adf4f12394380b2f6071ac1c0713bb0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='ce79aabc37c461f189765106e9a4a1f7defb4b89694514aaee6e8f6dbf604177'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='9c9a46c62a6e80db6d1a387cc0be50b85e19c8eefa52f74f9e56615bb050e475'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='ce1a18f62a4e08e0f4149514df08bb133acd220c542d3dfc99bf2d4bc8a5f47a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='7b203aa779f36946875f293b728d29cec334a7a155e6d98aed1b7cfb1f1bc8b8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='c1819feee7de0450af8da1be6ec6ad79c5f096fc01739fd64e4d881973b347da'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='c6a2faa2562228961ae3e78859a855e90e0b325b6e35a4e064f2f4fe5e0026d0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -22,26 +22,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='feef1adabd6624ea320b40e348b4e763f311cdc126a6af9d09e91c464bf317c3'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='8a706ac4be656fcba0b0bf6b8f055498adf4f12394380b2f6071ac1c0713bb0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='ce79aabc37c461f189765106e9a4a1f7defb4b89694514aaee6e8f6dbf604177'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='9c9a46c62a6e80db6d1a387cc0be50b85e19c8eefa52f74f9e56615bb050e475'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='ce1a18f62a4e08e0f4149514df08bb133acd220c542d3dfc99bf2d4bc8a5f47a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='7b203aa779f36946875f293b728d29cec334a7a155e6d98aed1b7cfb1f1bc8b8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='c1819feee7de0450af8da1be6ec6ad79c5f096fc01739fd64e4d881973b347da'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='c6a2faa2562228961ae3e78859a855e90e0b325b6e35a4e064f2f4fe5e0026d0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -22,26 +22,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='feef1adabd6624ea320b40e348b4e763f311cdc126a6af9d09e91c464bf317c3'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='8a706ac4be656fcba0b0bf6b8f055498adf4f12394380b2f6071ac1c0713bb0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='ce79aabc37c461f189765106e9a4a1f7defb4b89694514aaee6e8f6dbf604177'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='9c9a46c62a6e80db6d1a387cc0be50b85e19c8eefa52f74f9e56615bb050e475'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='ce1a18f62a4e08e0f4149514df08bb133acd220c542d3dfc99bf2d4bc8a5f47a'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='7b203aa779f36946875f293b728d29cec334a7a155e6d98aed1b7cfb1f1bc8b8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='c1819feee7de0450af8da1be6ec6ad79c5f096fc01739fd64e4d881973b347da'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='c6a2faa2562228961ae3e78859a855e90e0b325b6e35a4e064f2f4fe5e0026d0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/centos/Dockerfile.certified.releases.full
+++ b/11/jre/centos/Dockerfile.certified.releases.full
@@ -20,26 +20,26 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='485abc0c0c54d51cfbbaf19a2ac9d641a57c475caf82aa84708c28e4db9091df'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='51e144fb1bd54d1b04edb26f27b3bfdb17c34a3989adf038c46eb17cf6c39dd7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='b656232e562bf4b67bfca4f0986484172866abb602fa8d27f289ec776579f17f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='72a2c164ff6e3dd0b83f670215b60934ceacad20385e6228aa6151f8415dc524'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='94f2fe8dfef4389cdc49e7139e006fa740eecccd4956428fb489dfa2e973b9ea'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='d2e8807d42b4eb09b53e9ec56b089d700159dbe9b0aeefb582f80ed969d23e6b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='f9a4bf122ee4465c5a93204f2a34f7214b2f1969193f9c3436dd6b8b5c0cd45b'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='3cc1e7f666b48e1a72e51fb20158c08d212b85a037a268aa8d3549fb4693ac64'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.27.0" \
+      version="11.0.28.0" \
       release="11" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='485abc0c0c54d51cfbbaf19a2ac9d641a57c475caf82aa84708c28e4db9091df'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='51e144fb1bd54d1b04edb26f27b3bfdb17c34a3989adf038c46eb17cf6c39dd7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='b656232e562bf4b67bfca4f0986484172866abb602fa8d27f289ec776579f17f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='72a2c164ff6e3dd0b83f670215b60934ceacad20385e6228aa6151f8415dc524'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='94f2fe8dfef4389cdc49e7139e006fa740eecccd4956428fb489dfa2e973b9ea'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='d2e8807d42b4eb09b53e9ec56b089d700159dbe9b0aeefb582f80ed969d23e6b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='f9a4bf122ee4465c5a93204f2a34f7214b2f1969193f9c3436dd6b8b5c0cd45b'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='3cc1e7f666b48e1a72e51fb20158c08d212b85a037a268aa8d3549fb4693ac64'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.27.0" \
+      version="11.0.28.0" \
       release="11" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='485abc0c0c54d51cfbbaf19a2ac9d641a57c475caf82aa84708c28e4db9091df'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='51e144fb1bd54d1b04edb26f27b3bfdb17c34a3989adf038c46eb17cf6c39dd7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='b656232e562bf4b67bfca4f0986484172866abb602fa8d27f289ec776579f17f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='72a2c164ff6e3dd0b83f670215b60934ceacad20385e6228aa6151f8415dc524'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='94f2fe8dfef4389cdc49e7139e006fa740eecccd4956428fb489dfa2e973b9ea'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='d2e8807d42b4eb09b53e9ec56b089d700159dbe9b0aeefb582f80ed969d23e6b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='f9a4bf122ee4465c5a93204f2a34f7214b2f1969193f9c3436dd6b8b5c0cd45b'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='3cc1e7f666b48e1a72e51fb20158c08d212b85a037a268aa8d3549fb4693ac64'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -82,26 +82,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='485abc0c0c54d51cfbbaf19a2ac9d641a57c475caf82aa84708c28e4db9091df'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='51e144fb1bd54d1b04edb26f27b3bfdb17c34a3989adf038c46eb17cf6c39dd7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='b656232e562bf4b67bfca4f0986484172866abb602fa8d27f289ec776579f17f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='72a2c164ff6e3dd0b83f670215b60934ceacad20385e6228aa6151f8415dc524'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='94f2fe8dfef4389cdc49e7139e006fa740eecccd4956428fb489dfa2e973b9ea'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='d2e8807d42b4eb09b53e9ec56b089d700159dbe9b0aeefb582f80ed969d23e6b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='f9a4bf122ee4465c5a93204f2a34f7214b2f1969193f9c3436dd6b8b5c0cd45b'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='3cc1e7f666b48e1a72e51fb20158c08d212b85a037a268aa8d3549fb4693ac64'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="11.0.27.0" \
+      version="11.0.28.0" \
       release="11" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -82,26 +82,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='485abc0c0c54d51cfbbaf19a2ac9d641a57c475caf82aa84708c28e4db9091df'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='51e144fb1bd54d1b04edb26f27b3bfdb17c34a3989adf038c46eb17cf6c39dd7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='b656232e562bf4b67bfca4f0986484172866abb602fa8d27f289ec776579f17f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='72a2c164ff6e3dd0b83f670215b60934ceacad20385e6228aa6151f8415dc524'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='94f2fe8dfef4389cdc49e7139e006fa740eecccd4956428fb489dfa2e973b9ea'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='d2e8807d42b4eb09b53e9ec56b089d700159dbe9b0aeefb582f80ed969d23e6b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='f9a4bf122ee4465c5a93204f2a34f7214b2f1969193f9c3436dd6b8b5c0cd45b'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='3cc1e7f666b48e1a72e51fb20158c08d212b85a037a268aa8d3549fb4693ac64'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -22,26 +22,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='485abc0c0c54d51cfbbaf19a2ac9d641a57c475caf82aa84708c28e4db9091df'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='51e144fb1bd54d1b04edb26f27b3bfdb17c34a3989adf038c46eb17cf6c39dd7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='b656232e562bf4b67bfca4f0986484172866abb602fa8d27f289ec776579f17f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='72a2c164ff6e3dd0b83f670215b60934ceacad20385e6228aa6151f8415dc524'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='94f2fe8dfef4389cdc49e7139e006fa740eecccd4956428fb489dfa2e973b9ea'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='d2e8807d42b4eb09b53e9ec56b089d700159dbe9b0aeefb582f80ed969d23e6b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='f9a4bf122ee4465c5a93204f2a34f7214b2f1969193f9c3436dd6b8b5c0cd45b'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='3cc1e7f666b48e1a72e51fb20158c08d212b85a037a268aa8d3549fb4693ac64'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -22,26 +22,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='485abc0c0c54d51cfbbaf19a2ac9d641a57c475caf82aa84708c28e4db9091df'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='51e144fb1bd54d1b04edb26f27b3bfdb17c34a3989adf038c46eb17cf6c39dd7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='b656232e562bf4b67bfca4f0986484172866abb602fa8d27f289ec776579f17f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='72a2c164ff6e3dd0b83f670215b60934ceacad20385e6228aa6151f8415dc524'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='94f2fe8dfef4389cdc49e7139e006fa740eecccd4956428fb489dfa2e973b9ea'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='d2e8807d42b4eb09b53e9ec56b089d700159dbe9b0aeefb582f80ed969d23e6b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='f9a4bf122ee4465c5a93204f2a34f7214b2f1969193f9c3436dd6b8b5c0cd45b'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='3cc1e7f666b48e1a72e51fb20158c08d212b85a037a268aa8d3549fb4693ac64'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/11/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -22,26 +22,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 11.0.27.0
+ENV JAVA_VERSION 11.0.28.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='485abc0c0c54d51cfbbaf19a2ac9d641a57c475caf82aa84708c28e4db9091df'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_11.0.27.0.tar.gz'; \
+         ESUM='51e144fb1bd54d1b04edb26f27b3bfdb17c34a3989adf038c46eb17cf6c39dd7'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_11.0.28.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='b656232e562bf4b67bfca4f0986484172866abb602fa8d27f289ec776579f17f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.27.0.tar.gz'; \
+         ESUM='72a2c164ff6e3dd0b83f670215b60934ceacad20385e6228aa6151f8415dc524'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_11.0.28.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='94f2fe8dfef4389cdc49e7139e006fa740eecccd4956428fb489dfa2e973b9ea'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_11.0.27.0.tar.gz'; \
+         ESUM='d2e8807d42b4eb09b53e9ec56b089d700159dbe9b0aeefb582f80ed969d23e6b'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_11.0.28.0.tar.gz'; \
          ;; \
        aarch64|arm64) \
-         ESUM='f9a4bf122ee4465c5a93204f2a34f7214b2f1969193f9c3436dd6b8b5c0cd45b'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.27%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_11.0.27.0.tar.gz'; \
+         ESUM='3cc1e7f666b48e1a72e51fb20158c08d212b85a037a268aa8d3549fb4693ac64'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru11-certified-binaries/releases/download/jdk-11.0.28%2B6_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_11.0.28.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/centos/Dockerfile.certified.releases.full
+++ b/17/jdk/centos/Dockerfile.certified.releases.full
@@ -20,26 +20,26 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='402a034c3cc862354e5db8eddafebc23f1e02f70c7bfd6dd355124d99d96de83'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='db6e58c25c20179f75f46e3d704145099047b0cfc9703e7b722f612c9b42e4fe'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d09cf71a634ff5bcd28b7027e238cc7c2d07bf9dd0a1af04463e08d970a113b7'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='31e46e3a3c3a015436fa99785caa3984b86c007e0dd3a67d2dcb0f338fe19db4'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4e4b197e29946118cfd1d3fa1cfab0b250db826ddb653b33c2b5082e475d9d19'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3218380275b1fbc410c7ba4824ba13b529440a82a37f7a2ef481399ec551ab0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fd53b5e60962b96197493423154334d487817af878dccce5526ae384bf0f9b78'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='c46c111c74a1cd237df9d2defc44566fdd5dee52f7797f61f1f1d19cedee2c9f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.15.0" \
+      version="17.0.16.0" \
       release="17" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='402a034c3cc862354e5db8eddafebc23f1e02f70c7bfd6dd355124d99d96de83'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='db6e58c25c20179f75f46e3d704145099047b0cfc9703e7b722f612c9b42e4fe'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d09cf71a634ff5bcd28b7027e238cc7c2d07bf9dd0a1af04463e08d970a113b7'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='31e46e3a3c3a015436fa99785caa3984b86c007e0dd3a67d2dcb0f338fe19db4'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4e4b197e29946118cfd1d3fa1cfab0b250db826ddb653b33c2b5082e475d9d19'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3218380275b1fbc410c7ba4824ba13b529440a82a37f7a2ef481399ec551ab0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fd53b5e60962b96197493423154334d487817af878dccce5526ae384bf0f9b78'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='c46c111c74a1cd237df9d2defc44566fdd5dee52f7797f61f1f1d19cedee2c9f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.15.0" \
+      version="17.0.16.0" \
       release="17" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='402a034c3cc862354e5db8eddafebc23f1e02f70c7bfd6dd355124d99d96de83'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='db6e58c25c20179f75f46e3d704145099047b0cfc9703e7b722f612c9b42e4fe'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d09cf71a634ff5bcd28b7027e238cc7c2d07bf9dd0a1af04463e08d970a113b7'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='31e46e3a3c3a015436fa99785caa3984b86c007e0dd3a67d2dcb0f338fe19db4'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4e4b197e29946118cfd1d3fa1cfab0b250db826ddb653b33c2b5082e475d9d19'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3218380275b1fbc410c7ba4824ba13b529440a82a37f7a2ef481399ec551ab0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fd53b5e60962b96197493423154334d487817af878dccce5526ae384bf0f9b78'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='c46c111c74a1cd237df9d2defc44566fdd5dee52f7797f61f1f1d19cedee2c9f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.15.0" \
+      version="17.0.16.0" \
       release="17" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='402a034c3cc862354e5db8eddafebc23f1e02f70c7bfd6dd355124d99d96de83'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='db6e58c25c20179f75f46e3d704145099047b0cfc9703e7b722f612c9b42e4fe'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d09cf71a634ff5bcd28b7027e238cc7c2d07bf9dd0a1af04463e08d970a113b7'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='31e46e3a3c3a015436fa99785caa3984b86c007e0dd3a67d2dcb0f338fe19db4'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4e4b197e29946118cfd1d3fa1cfab0b250db826ddb653b33c2b5082e475d9d19'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3218380275b1fbc410c7ba4824ba13b529440a82a37f7a2ef481399ec551ab0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fd53b5e60962b96197493423154334d487817af878dccce5526ae384bf0f9b78'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='c46c111c74a1cd237df9d2defc44566fdd5dee52f7797f61f1f1d19cedee2c9f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.15.0" \
+      version="17.0.16.0" \
       release="17" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='402a034c3cc862354e5db8eddafebc23f1e02f70c7bfd6dd355124d99d96de83'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='db6e58c25c20179f75f46e3d704145099047b0cfc9703e7b722f612c9b42e4fe'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d09cf71a634ff5bcd28b7027e238cc7c2d07bf9dd0a1af04463e08d970a113b7'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='31e46e3a3c3a015436fa99785caa3984b86c007e0dd3a67d2dcb0f338fe19db4'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4e4b197e29946118cfd1d3fa1cfab0b250db826ddb653b33c2b5082e475d9d19'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3218380275b1fbc410c7ba4824ba13b529440a82a37f7a2ef481399ec551ab0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fd53b5e60962b96197493423154334d487817af878dccce5526ae384bf0f9b78'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='c46c111c74a1cd237df9d2defc44566fdd5dee52f7797f61f1f1d19cedee2c9f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='402a034c3cc862354e5db8eddafebc23f1e02f70c7bfd6dd355124d99d96de83'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='db6e58c25c20179f75f46e3d704145099047b0cfc9703e7b722f612c9b42e4fe'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d09cf71a634ff5bcd28b7027e238cc7c2d07bf9dd0a1af04463e08d970a113b7'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='31e46e3a3c3a015436fa99785caa3984b86c007e0dd3a67d2dcb0f338fe19db4'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4e4b197e29946118cfd1d3fa1cfab0b250db826ddb653b33c2b5082e475d9d19'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3218380275b1fbc410c7ba4824ba13b529440a82a37f7a2ef481399ec551ab0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fd53b5e60962b96197493423154334d487817af878dccce5526ae384bf0f9b78'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='c46c111c74a1cd237df9d2defc44566fdd5dee52f7797f61f1f1d19cedee2c9f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='402a034c3cc862354e5db8eddafebc23f1e02f70c7bfd6dd355124d99d96de83'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='db6e58c25c20179f75f46e3d704145099047b0cfc9703e7b722f612c9b42e4fe'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d09cf71a634ff5bcd28b7027e238cc7c2d07bf9dd0a1af04463e08d970a113b7'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='31e46e3a3c3a015436fa99785caa3984b86c007e0dd3a67d2dcb0f338fe19db4'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4e4b197e29946118cfd1d3fa1cfab0b250db826ddb653b33c2b5082e475d9d19'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3218380275b1fbc410c7ba4824ba13b529440a82a37f7a2ef481399ec551ab0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fd53b5e60962b96197493423154334d487817af878dccce5526ae384bf0f9b78'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='c46c111c74a1cd237df9d2defc44566fdd5dee52f7797f61f1f1d19cedee2c9f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='402a034c3cc862354e5db8eddafebc23f1e02f70c7bfd6dd355124d99d96de83'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='db6e58c25c20179f75f46e3d704145099047b0cfc9703e7b722f612c9b42e4fe'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='d09cf71a634ff5bcd28b7027e238cc7c2d07bf9dd0a1af04463e08d970a113b7'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='31e46e3a3c3a015436fa99785caa3984b86c007e0dd3a67d2dcb0f338fe19db4'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='4e4b197e29946118cfd1d3fa1cfab0b250db826ddb653b33c2b5082e475d9d19'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3218380275b1fbc410c7ba4824ba13b529440a82a37f7a2ef481399ec551ab0f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='fd53b5e60962b96197493423154334d487817af878dccce5526ae384bf0f9b78'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='c46c111c74a1cd237df9d2defc44566fdd5dee52f7797f61f1f1d19cedee2c9f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/centos/Dockerfile.certified.releases.full
+++ b/17/jre/centos/Dockerfile.certified.releases.full
@@ -20,26 +20,26 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c1529e9cd478311ea2745b99ab78ac8eea6a292058cd11e66f640e8b9ec2c06f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='c1d325b46d970e429a6a1db536fcd138facaeb0c34b96d43be6aeb3622d05d14'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6ee8297ba5030ebdc396b34b7c9967bf5615c9e558460fd427aef496da034503'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='e373edc326a84559b06c82292d5fec3ec3a63e22ebe6df36b8a8d6aa3ffa1de0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='e990b1e778e08b98fdbf8e600056a3f5f2511986b0578abce41238ca7265e50c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3efd4cda887ae7f8109355dd994ef562bedd7a40713810f68068c0f93dcc7d7e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3f5b4a879a560b5bc048ab8481d56510736da88d293c56af90d96f4b1fc890ff'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='3977de84960f43b17eae19bc41451949a1486eb4dfc1261fa5a4f6be4c576cc8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.15.0" \
+      version="17.0.16.0" \
       release="17" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c1529e9cd478311ea2745b99ab78ac8eea6a292058cd11e66f640e8b9ec2c06f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='c1d325b46d970e429a6a1db536fcd138facaeb0c34b96d43be6aeb3622d05d14'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6ee8297ba5030ebdc396b34b7c9967bf5615c9e558460fd427aef496da034503'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='e373edc326a84559b06c82292d5fec3ec3a63e22ebe6df36b8a8d6aa3ffa1de0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='e990b1e778e08b98fdbf8e600056a3f5f2511986b0578abce41238ca7265e50c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3efd4cda887ae7f8109355dd994ef562bedd7a40713810f68068c0f93dcc7d7e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3f5b4a879a560b5bc048ab8481d56510736da88d293c56af90d96f4b1fc890ff'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='3977de84960f43b17eae19bc41451949a1486eb4dfc1261fa5a4f6be4c576cc8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.15.0" \
+      version="17.0.16.0" \
       release="17" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c1529e9cd478311ea2745b99ab78ac8eea6a292058cd11e66f640e8b9ec2c06f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='c1d325b46d970e429a6a1db536fcd138facaeb0c34b96d43be6aeb3622d05d14'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6ee8297ba5030ebdc396b34b7c9967bf5615c9e558460fd427aef496da034503'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='e373edc326a84559b06c82292d5fec3ec3a63e22ebe6df36b8a8d6aa3ffa1de0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='e990b1e778e08b98fdbf8e600056a3f5f2511986b0578abce41238ca7265e50c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3efd4cda887ae7f8109355dd994ef562bedd7a40713810f68068c0f93dcc7d7e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3f5b4a879a560b5bc048ab8481d56510736da88d293c56af90d96f4b1fc890ff'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='3977de84960f43b17eae19bc41451949a1486eb4dfc1261fa5a4f6be4c576cc8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.15.0" \
+      version="17.0.16.0" \
       release="17" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c1529e9cd478311ea2745b99ab78ac8eea6a292058cd11e66f640e8b9ec2c06f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='c1d325b46d970e429a6a1db536fcd138facaeb0c34b96d43be6aeb3622d05d14'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6ee8297ba5030ebdc396b34b7c9967bf5615c9e558460fd427aef496da034503'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='e373edc326a84559b06c82292d5fec3ec3a63e22ebe6df36b8a8d6aa3ffa1de0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='e990b1e778e08b98fdbf8e600056a3f5f2511986b0578abce41238ca7265e50c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3efd4cda887ae7f8109355dd994ef562bedd7a40713810f68068c0f93dcc7d7e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3f5b4a879a560b5bc048ab8481d56510736da88d293c56af90d96f4b1fc890ff'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='3977de84960f43b17eae19bc41451949a1486eb4dfc1261fa5a4f6be4c576cc8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="17.0.15.0" \
+      version="17.0.16.0" \
       release="17" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,26 +81,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c1529e9cd478311ea2745b99ab78ac8eea6a292058cd11e66f640e8b9ec2c06f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='c1d325b46d970e429a6a1db536fcd138facaeb0c34b96d43be6aeb3622d05d14'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6ee8297ba5030ebdc396b34b7c9967bf5615c9e558460fd427aef496da034503'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='e373edc326a84559b06c82292d5fec3ec3a63e22ebe6df36b8a8d6aa3ffa1de0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='e990b1e778e08b98fdbf8e600056a3f5f2511986b0578abce41238ca7265e50c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3efd4cda887ae7f8109355dd994ef562bedd7a40713810f68068c0f93dcc7d7e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3f5b4a879a560b5bc048ab8481d56510736da88d293c56af90d96f4b1fc890ff'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='3977de84960f43b17eae19bc41451949a1486eb4dfc1261fa5a4f6be4c576cc8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c1529e9cd478311ea2745b99ab78ac8eea6a292058cd11e66f640e8b9ec2c06f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='c1d325b46d970e429a6a1db536fcd138facaeb0c34b96d43be6aeb3622d05d14'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6ee8297ba5030ebdc396b34b7c9967bf5615c9e558460fd427aef496da034503'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='e373edc326a84559b06c82292d5fec3ec3a63e22ebe6df36b8a8d6aa3ffa1de0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='e990b1e778e08b98fdbf8e600056a3f5f2511986b0578abce41238ca7265e50c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3efd4cda887ae7f8109355dd994ef562bedd7a40713810f68068c0f93dcc7d7e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3f5b4a879a560b5bc048ab8481d56510736da88d293c56af90d96f4b1fc890ff'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='3977de84960f43b17eae19bc41451949a1486eb4dfc1261fa5a4f6be4c576cc8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c1529e9cd478311ea2745b99ab78ac8eea6a292058cd11e66f640e8b9ec2c06f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='c1d325b46d970e429a6a1db536fcd138facaeb0c34b96d43be6aeb3622d05d14'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6ee8297ba5030ebdc396b34b7c9967bf5615c9e558460fd427aef496da034503'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='e373edc326a84559b06c82292d5fec3ec3a63e22ebe6df36b8a8d6aa3ffa1de0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='e990b1e778e08b98fdbf8e600056a3f5f2511986b0578abce41238ca7265e50c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3efd4cda887ae7f8109355dd994ef562bedd7a40713810f68068c0f93dcc7d7e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3f5b4a879a560b5bc048ab8481d56510736da88d293c56af90d96f4b1fc890ff'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='3977de84960f43b17eae19bc41451949a1486eb4dfc1261fa5a4f6be4c576cc8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/17/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 17.0.15.0
+ENV JAVA_VERSION 17.0.16.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='c1529e9cd478311ea2745b99ab78ac8eea6a292058cd11e66f640e8b9ec2c06f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_17.0.15.0.tar.gz'; \
+         ESUM='c1d325b46d970e429a6a1db536fcd138facaeb0c34b96d43be6aeb3622d05d14'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_17.0.16.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='6ee8297ba5030ebdc396b34b7c9967bf5615c9e558460fd427aef496da034503'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_17.0.15.0.tar.gz'; \
+         ESUM='e373edc326a84559b06c82292d5fec3ec3a63e22ebe6df36b8a8d6aa3ffa1de0'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_17.0.16.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='e990b1e778e08b98fdbf8e600056a3f5f2511986b0578abce41238ca7265e50c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.15.0.tar.gz'; \
+         ESUM='3efd4cda887ae7f8109355dd994ef562bedd7a40713810f68068c0f93dcc7d7e'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_17.0.16.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='3f5b4a879a560b5bc048ab8481d56510736da88d293c56af90d96f4b1fc890ff'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.15%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_17.0.15.0.tar.gz'; \
+         ESUM='3977de84960f43b17eae19bc41451949a1486eb4dfc1261fa5a4f6be4c576cc8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru17-certified-binaries/releases/download/jdk-17.0.16%2B8_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_17.0.16.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jdk/centos/Dockerfile.certified.releases.full
+++ b/21/jdk/centos/Dockerfile.certified.releases.full
@@ -20,26 +20,26 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6fcaad412c56ce07d09622a73e7d68864b8cdee303aa22a1f1dffca064dc214f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='02b85f31e8c9a9eb43f058459c023840dec8e00fdbaa753f9d0265b3465352b2'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='0ddbb6b7060d10286d62e51d1ae5942200282dac7234ffc866a66b62e8526ed2'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='030271854cefdd56ede65a9c2afb09ae29d016fa0ab64bf983b75af17691917f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='36f04ea7b04351abb162708190ff797b769567c3a8bd46bfe0d21a83ad322883'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='7e92104e40fea9154987f98b93809db9c6cca4ab4c5710ad8d707723446de269'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='1f9c7b4dfdce1345673247b3dc6b9a6d8a8614da47cb3afb4e2afda86719c25c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='e1cabbdc5a4b2d9a2c647bf7b59bd98babb74fe9b88ba09a33f85160e775f50c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="21.0.7.0" \
+      version="21.0.8.0" \
       release="21" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,27 +81,27 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
     set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6fcaad412c56ce07d09622a73e7d68864b8cdee303aa22a1f1dffca064dc214f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='02b85f31e8c9a9eb43f058459c023840dec8e00fdbaa753f9d0265b3465352b2'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='0ddbb6b7060d10286d62e51d1ae5942200282dac7234ffc866a66b62e8526ed2'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='030271854cefdd56ede65a9c2afb09ae29d016fa0ab64bf983b75af17691917f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='36f04ea7b04351abb162708190ff797b769567c3a8bd46bfe0d21a83ad322883'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='7e92104e40fea9154987f98b93809db9c6cca4ab4c5710ad8d707723446de269'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='1f9c7b4dfdce1345673247b3dc6b9a6d8a8614da47cb3afb4e2afda86719c25c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='e1cabbdc5a4b2d9a2c647bf7b59bd98babb74fe9b88ba09a33f85160e775f50c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -27,7 +27,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="21.0.7.0" \
+      version="21.0.8.0" \
       release="21" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -76,27 +76,27 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
     set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6fcaad412c56ce07d09622a73e7d68864b8cdee303aa22a1f1dffca064dc214f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='02b85f31e8c9a9eb43f058459c023840dec8e00fdbaa753f9d0265b3465352b2'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='0ddbb6b7060d10286d62e51d1ae5942200282dac7234ffc866a66b62e8526ed2'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='030271854cefdd56ede65a9c2afb09ae29d016fa0ab64bf983b75af17691917f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='36f04ea7b04351abb162708190ff797b769567c3a8bd46bfe0d21a83ad322883'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='7e92104e40fea9154987f98b93809db9c6cca4ab4c5710ad8d707723446de269'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='1f9c7b4dfdce1345673247b3dc6b9a6d8a8614da47cb3afb4e2afda86719c25c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='e1cabbdc5a4b2d9a2c647bf7b59bd98babb74fe9b88ba09a33f85160e775f50c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="21.0.7.0" \
+      version="21.0.8.0" \
       release="21" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,27 +81,27 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
     set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6fcaad412c56ce07d09622a73e7d68864b8cdee303aa22a1f1dffca064dc214f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='02b85f31e8c9a9eb43f058459c023840dec8e00fdbaa753f9d0265b3465352b2'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='0ddbb6b7060d10286d62e51d1ae5942200282dac7234ffc866a66b62e8526ed2'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='030271854cefdd56ede65a9c2afb09ae29d016fa0ab64bf983b75af17691917f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='36f04ea7b04351abb162708190ff797b769567c3a8bd46bfe0d21a83ad322883'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='7e92104e40fea9154987f98b93809db9c6cca4ab4c5710ad8d707723446de269'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='1f9c7b4dfdce1345673247b3dc6b9a6d8a8614da47cb3afb4e2afda86719c25c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='e1cabbdc5a4b2d9a2c647bf7b59bd98babb74fe9b88ba09a33f85160e775f50c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="21.0.7.0" \
+      version="21.0.8.0" \
       release="21" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -75,27 +75,27 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
     set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6fcaad412c56ce07d09622a73e7d68864b8cdee303aa22a1f1dffca064dc214f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='02b85f31e8c9a9eb43f058459c023840dec8e00fdbaa753f9d0265b3465352b2'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='0ddbb6b7060d10286d62e51d1ae5942200282dac7234ffc866a66b62e8526ed2'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='030271854cefdd56ede65a9c2afb09ae29d016fa0ab64bf983b75af17691917f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='36f04ea7b04351abb162708190ff797b769567c3a8bd46bfe0d21a83ad322883'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='7e92104e40fea9154987f98b93809db9c6cca4ab4c5710ad8d707723446de269'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='1f9c7b4dfdce1345673247b3dc6b9a6d8a8614da47cb3afb4e2afda86719c25c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='e1cabbdc5a4b2d9a2c647bf7b59bd98babb74fe9b88ba09a33f85160e775f50c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6fcaad412c56ce07d09622a73e7d68864b8cdee303aa22a1f1dffca064dc214f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='02b85f31e8c9a9eb43f058459c023840dec8e00fdbaa753f9d0265b3465352b2'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='0ddbb6b7060d10286d62e51d1ae5942200282dac7234ffc866a66b62e8526ed2'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='030271854cefdd56ede65a9c2afb09ae29d016fa0ab64bf983b75af17691917f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='36f04ea7b04351abb162708190ff797b769567c3a8bd46bfe0d21a83ad322883'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='7e92104e40fea9154987f98b93809db9c6cca4ab4c5710ad8d707723446de269'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='1f9c7b4dfdce1345673247b3dc6b9a6d8a8614da47cb3afb4e2afda86719c25c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='e1cabbdc5a4b2d9a2c647bf7b59bd98babb74fe9b88ba09a33f85160e775f50c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6fcaad412c56ce07d09622a73e7d68864b8cdee303aa22a1f1dffca064dc214f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='02b85f31e8c9a9eb43f058459c023840dec8e00fdbaa753f9d0265b3465352b2'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='0ddbb6b7060d10286d62e51d1ae5942200282dac7234ffc866a66b62e8526ed2'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='030271854cefdd56ede65a9c2afb09ae29d016fa0ab64bf983b75af17691917f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='36f04ea7b04351abb162708190ff797b769567c3a8bd46bfe0d21a83ad322883'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='7e92104e40fea9154987f98b93809db9c6cca4ab4c5710ad8d707723446de269'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='1f9c7b4dfdce1345673247b3dc6b9a6d8a8614da47cb3afb4e2afda86719c25c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='e1cabbdc5a4b2d9a2c647bf7b59bd98babb74fe9b88ba09a33f85160e775f50c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/21/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='6fcaad412c56ce07d09622a73e7d68864b8cdee303aa22a1f1dffca064dc214f'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='02b85f31e8c9a9eb43f058459c023840dec8e00fdbaa753f9d0265b3465352b2'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='0ddbb6b7060d10286d62e51d1ae5942200282dac7234ffc866a66b62e8526ed2'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='030271854cefdd56ede65a9c2afb09ae29d016fa0ab64bf983b75af17691917f'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='36f04ea7b04351abb162708190ff797b769567c3a8bd46bfe0d21a83ad322883'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='7e92104e40fea9154987f98b93809db9c6cca4ab4c5710ad8d707723446de269'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='1f9c7b4dfdce1345673247b3dc6b9a6d8a8614da47cb3afb4e2afda86719c25c'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jdk_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='e1cabbdc5a4b2d9a2c647bf7b59bd98babb74fe9b88ba09a33f85160e775f50c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jdk_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jre/centos/Dockerfile.certified.releases.full
+++ b/21/jre/centos/Dockerfile.certified.releases.full
@@ -20,26 +20,26 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='08936f5ada4969192dc10f19953b23b5b7562dea65764cd2555be53ba437aa1d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4a1a6f5b86aef9fe3dfd805d54e467795f8b0fb16b77a09dedcf52b3be34baca'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='71806416e7c93cdd671a05718a384371943da1f850ccba3a5cf4ab49dd775397'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4cb84965277418804d13ac48779111d5eaa7e8a1a5ed64eaf4fe264a997ef7a8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='199c3e699b35a9eeb7f35832b95a2c4bb27fd957065dfa9128f03d2f2359ec90'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='30124e4230ae8aad69f9194891336034be7039cfca4925bd31477b8da52d7159'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c54d3642464edad56ab09201faca2fd70520717e17163737643c71dcecd0a074'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='b315ab76a8afe05a1357485ec0792223dd3dc2e0a57b947988153d5ed9798e9c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/21/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="21.0.7.0" \
+      version="21.0.8.0" \
       release="21" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,27 +81,27 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
     set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='08936f5ada4969192dc10f19953b23b5b7562dea65764cd2555be53ba437aa1d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4a1a6f5b86aef9fe3dfd805d54e467795f8b0fb16b77a09dedcf52b3be34baca'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='71806416e7c93cdd671a05718a384371943da1f850ccba3a5cf4ab49dd775397'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4cb84965277418804d13ac48779111d5eaa7e8a1a5ed64eaf4fe264a997ef7a8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='199c3e699b35a9eeb7f35832b95a2c4bb27fd957065dfa9128f03d2f2359ec90'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='30124e4230ae8aad69f9194891336034be7039cfca4925bd31477b8da52d7159'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c54d3642464edad56ab09201faca2fd70520717e17163737643c71dcecd0a074'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='b315ab76a8afe05a1357485ec0792223dd3dc2e0a57b947988153d5ed9798e9c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/21/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN microdnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="21.0.7.0" \
+      version="21.0.8.0" \
       release="21" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -81,27 +81,27 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
     set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='08936f5ada4969192dc10f19953b23b5b7562dea65764cd2555be53ba437aa1d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4a1a6f5b86aef9fe3dfd805d54e467795f8b0fb16b77a09dedcf52b3be34baca'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='71806416e7c93cdd671a05718a384371943da1f850ccba3a5cf4ab49dd775397'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4cb84965277418804d13ac48779111d5eaa7e8a1a5ed64eaf4fe264a997ef7a8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='199c3e699b35a9eeb7f35832b95a2c4bb27fd957065dfa9128f03d2f2359ec90'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='30124e4230ae8aad69f9194891336034be7039cfca4925bd31477b8da52d7159'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c54d3642464edad56ab09201faca2fd70520717e17163737643c71dcecd0a074'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='b315ab76a8afe05a1357485ec0792223dd3dc2e0a57b947988153d5ed9798e9c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/21/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="21.0.7.0" \
+      version="21.0.8.0" \
       release="21" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -75,26 +75,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='08936f5ada4969192dc10f19953b23b5b7562dea65764cd2555be53ba437aa1d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4a1a6f5b86aef9fe3dfd805d54e467795f8b0fb16b77a09dedcf52b3be34baca'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='71806416e7c93cdd671a05718a384371943da1f850ccba3a5cf4ab49dd775397'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4cb84965277418804d13ac48779111d5eaa7e8a1a5ed64eaf4fe264a997ef7a8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='199c3e699b35a9eeb7f35832b95a2c4bb27fd957065dfa9128f03d2f2359ec90'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='30124e4230ae8aad69f9194891336034be7039cfca4925bd31477b8da52d7159'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c54d3642464edad56ab09201faca2fd70520717e17163737643c71dcecd0a074'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='b315ab76a8afe05a1357485ec0792223dd3dc2e0a57b947988153d5ed9798e9c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/21/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -26,7 +26,7 @@ RUN dnf install -y \
 
 LABEL name="IBM Semeru Runtime Certified Edition" \
       vendor="International Business Machines Corporation" \
-      version="21.0.7.0" \
+      version="21.0.8.0" \
       release="21" \
       maintainer="jayasg12@in.ibm.com" \
       run="docker run --rm -ti <image_name:tag> /bin/bash" \
@@ -75,26 +75,26 @@ RUN --mount=type=secret,id=criu_secrets source /run/secrets/criu_secrets; \
 
 ENV PATH="/usr/local/sbin:$PATH"
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='08936f5ada4969192dc10f19953b23b5b7562dea65764cd2555be53ba437aa1d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4a1a6f5b86aef9fe3dfd805d54e467795f8b0fb16b77a09dedcf52b3be34baca'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='71806416e7c93cdd671a05718a384371943da1f850ccba3a5cf4ab49dd775397'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4cb84965277418804d13ac48779111d5eaa7e8a1a5ed64eaf4fe264a997ef7a8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='199c3e699b35a9eeb7f35832b95a2c4bb27fd957065dfa9128f03d2f2359ec90'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='30124e4230ae8aad69f9194891336034be7039cfca4925bd31477b8da52d7159'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c54d3642464edad56ab09201faca2fd70520717e17163737643c71dcecd0a074'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='b315ab76a8afe05a1357485ec0792223dd3dc2e0a57b947988153d5ed9798e9c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='08936f5ada4969192dc10f19953b23b5b7562dea65764cd2555be53ba437aa1d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4a1a6f5b86aef9fe3dfd805d54e467795f8b0fb16b77a09dedcf52b3be34baca'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='71806416e7c93cdd671a05718a384371943da1f850ccba3a5cf4ab49dd775397'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4cb84965277418804d13ac48779111d5eaa7e8a1a5ed64eaf4fe264a997ef7a8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='199c3e699b35a9eeb7f35832b95a2c4bb27fd957065dfa9128f03d2f2359ec90'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='30124e4230ae8aad69f9194891336034be7039cfca4925bd31477b8da52d7159'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c54d3642464edad56ab09201faca2fd70520717e17163737643c71dcecd0a074'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='b315ab76a8afe05a1357485ec0792223dd3dc2e0a57b947988153d5ed9798e9c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='08936f5ada4969192dc10f19953b23b5b7562dea65764cd2555be53ba437aa1d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4a1a6f5b86aef9fe3dfd805d54e467795f8b0fb16b77a09dedcf52b3be34baca'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='71806416e7c93cdd671a05718a384371943da1f850ccba3a5cf4ab49dd775397'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4cb84965277418804d13ac48779111d5eaa7e8a1a5ed64eaf4fe264a997ef7a8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='199c3e699b35a9eeb7f35832b95a2c4bb27fd957065dfa9128f03d2f2359ec90'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='30124e4230ae8aad69f9194891336034be7039cfca4925bd31477b8da52d7159'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c54d3642464edad56ab09201faca2fd70520717e17163737643c71dcecd0a074'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='b315ab76a8afe05a1357485ec0792223dd3dc2e0a57b947988153d5ed9798e9c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/21/jre/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/21/jre/ubuntu/noble/Dockerfile.certified.releases.full
@@ -23,26 +23,26 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION 21.0.7.0
+ENV JAVA_VERSION 21.0.8.0
 
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         ESUM='08936f5ada4969192dc10f19953b23b5b7562dea65764cd2555be53ba437aa1d'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_aarch64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4a1a6f5b86aef9fe3dfd805d54e467795f8b0fb16b77a09dedcf52b3be34baca'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_aarch64_linux_21.0.8.0.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         ESUM='71806416e7c93cdd671a05718a384371943da1f850ccba3a5cf4ab49dd775397'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_x64_linux_21.0.7.0.tar.gz'; \
+         ESUM='4cb84965277418804d13ac48779111d5eaa7e8a1a5ed64eaf4fe264a997ef7a8'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_x64_linux_21.0.8.0.tar.gz'; \
          ;; \
        ppc64el|ppc64le) \
-         ESUM='199c3e699b35a9eeb7f35832b95a2c4bb27fd957065dfa9128f03d2f2359ec90'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.7.0.tar.gz'; \
+         ESUM='30124e4230ae8aad69f9194891336034be7039cfca4925bd31477b8da52d7159'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_ppc64le_linux_21.0.8.0.tar.gz'; \
          ;; \
        s390x) \
-         ESUM='c54d3642464edad56ab09201faca2fd70520717e17163737643c71dcecd0a074'; \
-         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.7%2B6_openj9-0.51.0/ibm-semeru-certified-jre_s390x_linux_21.0.7.0.tar.gz'; \
+         ESUM='b315ab76a8afe05a1357485ec0792223dd3dc2e0a57b947988153d5ed9798e9c'; \
+         BINARY_URL='https://github.com/ibmruntimes/semeru21-certified-binaries/releases/download/jdk-21.0.8%2B9_openj9-0.53.0/ibm-semeru-certified-jre_s390x_linux_21.0.8.0.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \


### PR DESCRIPTION
Updated certified docker files with 25_03 releases 11.0.28.0,17.0.16.0,21.0.8.0.