### PR TITLE
Remove libbsd package from ubi10

### DIFF
--- a/criu/centos9_stream/Dockerfile
+++ b/criu/centos9_stream/Dockerfile
@@ -67,15 +67,16 @@ RUN dnf -y update && \
     vim \
     xmlto
 
-RUN cd /tmp; \
-    git clone -b ${CRIU_BRANCH} ${CRIU_REPO}; \
-    mv criu criu-build; \
-    cd criu-build; \
+RUN set -e \
+    && cd /tmp \
+    && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
+    && mv criu criu-build \
+    && cd criu-build \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA}; \
-    fi; \
-    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu; \
-    cd ../; \
-    tar -czf criu.tar.gz criu; \
-    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt; \
-    rm -rf criu-build;
+        git reset --hard ${CRIU_SHA} \
+    fi \
+    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    && cd ../ \
+    && tar -czf criu.tar.gz criu \
+    && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
+    && rm -rf criu-build

--- a/criu/centos9_stream/Dockerfile
+++ b/criu/centos9_stream/Dockerfile
@@ -71,11 +71,11 @@ RUN set -e \
     && cd /tmp \
     && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
     && mv criu criu-build \
-    && cd criu-build \
+    && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA} \
-    fi \
-    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+        git reset --hard ${CRIU_SHA}; \
+    fi; \
+    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \

--- a/criu/sles15/Dockerfile
+++ b/criu/sles15/Dockerfile
@@ -75,15 +75,16 @@ RUN zypper update -y && \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 100 \
     && update-alternatives --set python3 /usr/bin/python3.11
 
-RUN cd /tmp; \
-    git clone -b ${CRIU_BRANCH} ${CRIU_REPO}; \
-    mv criu criu-build; \
-    cd criu-build; \
+RUN set -e \
+    && cd /tmp \
+    && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
+    && mv criu criu-build \
+    && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA}; \
-    fi; \
-    make CC=/usr/bin/gcc-13 DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu; \
-    cd ../; \
-    tar -czf criu.tar.gz criu; \
-    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt; \
-    rm -rf criu-build;
+        git reset --hard ${CRIU_SHA} \
+    fi \
+    && make CC=/usr/bin/gcc-13 DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    && cd ../ \
+    && tar -czf criu.tar.gz criu \
+    && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
+    && rm -rf criu-build

--- a/criu/sles15/Dockerfile
+++ b/criu/sles15/Dockerfile
@@ -81,8 +81,8 @@ RUN set -e \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA} \
-    fi \
+        git reset --hard ${CRIU_SHA}; \
+    fi; \
     && make CC=/usr/bin/gcc-13 DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \

--- a/criu/sles16/Dockerfile
+++ b/criu/sles16/Dockerfile
@@ -93,3 +93,19 @@ RUN python3 -m pip install --upgrade pip setuptools && \
     tar -czf criu.tar.gz criu && \
     sha256sum criu.tar.gz > criu.tar.gz.sha256.txt && \
     rm -rf criu-build
+
+RUN set -e \
+    && cd /tmp \
+    && python3 -m pip install --upgrade pip setuptools \
+    && git config --global user.email "$(hostname)@$(hostname).com" \
+    && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
+    && mv criu criu-build \
+    && cd criu-build && \
+    if [ "x${CRIU_SHA}" != x ] ; then \
+        git reset --hard ${CRIU_SHA} \
+    fi \
+    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    && cd ../ \
+    && tar -czf criu.tar.gz criu \
+    && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
+    && rm -rf criu-build

--- a/criu/sles16/Dockerfile
+++ b/criu/sles16/Dockerfile
@@ -87,6 +87,9 @@ RUN set -e \
     if [ "x${CRIU_SHA}" != x ] ; then \
         git reset --hard ${CRIU_SHA}; \
     fi; \
+    git remote add upstream https://github.com/checkpoint-restore/criu.git \
+    && git fetch upstream criu-dev \
+    && git cherry-pick d3dfb663b1022ec89431a0e61113f55a771bc73c \
     && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \

--- a/criu/sles16/Dockerfile
+++ b/criu/sles16/Dockerfile
@@ -77,23 +77,6 @@ RUN zypper --gpg-auto-import-keys refresh && \
     vim \
     xmlto
 
-RUN python3 -m pip install --upgrade pip setuptools && \
-    git config --global user.email "$(hostname)@$(hostname).com" && \
-    git clone -b ${CRIU_BRANCH} ${CRIU_REPO} && \
-    mv criu criu-build && \
-    cd criu-build && \
-    if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA}; \
-    fi; \
-    git remote add upstream https://github.com/checkpoint-restore/criu.git && \
-    git fetch upstream criu-dev && \
-    git cherry-pick d3dfb663b1022ec89431a0e61113f55a771bc73c && \
-    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu && \
-    cd ../ && \
-    tar -czf criu.tar.gz criu && \
-    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt && \
-    rm -rf criu-build
-
 RUN set -e \
     && cd /tmp \
     && python3 -m pip install --upgrade pip setuptools \
@@ -102,8 +85,8 @@ RUN set -e \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA} \
-    fi \
+        git reset --hard ${CRIU_SHA}; \
+    fi; \
     && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \

--- a/criu/ubi10/Dockerfile
+++ b/criu/ubi10/Dockerfile
@@ -40,7 +40,6 @@ RUN yum -y update && yum install -y \
     iptables-libs \
     jansson \
     kernel-devel \
-    libbsd-devel \
     libcap \
     libcap-devel \
     libibverbs \

--- a/criu/ubi10/Dockerfile
+++ b/criu/ubi10/Dockerfile
@@ -60,18 +60,21 @@ RUN yum -y update && yum install -y \
     python3 \
     python3-pip \
     python3-protobuf \
+    python3-setuptools \
+    python3-wheel \
     vim \
     xmlto
 
-RUN cd /tmp; \
-    git clone -b ${CRIU_BRANCH} ${CRIU_REPO}; \
-    mv criu criu-build; \
-    cd criu-build; \
+RUN set -e \
+    && cd /tmp \
+    && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
+    && mv criu criu-build \
+    && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA}; \
-    fi; \
-    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu; \
-    cd ../; \
-    tar -czf criu.tar.gz criu; \
-    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt; \
-    rm -rf criu-build;
+        git reset --hard ${CRIU_SHA} \
+    fi \
+    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    && cd ../ \
+    && tar -czf criu.tar.gz criu \
+    && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
+    && rm -rf criu-build

--- a/criu/ubi10/Dockerfile
+++ b/criu/ubi10/Dockerfile
@@ -71,9 +71,9 @@ RUN set -e \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA} \
-    fi \
-    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+        git reset --hard ${CRIU_SHA}; \
+    fi; \
+    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \

--- a/criu/ubi8/Dockerfile
+++ b/criu/ubi8/Dockerfile
@@ -51,6 +51,7 @@ RUN yum -y update && yum install -y \
     python3-protobuf \
     python3-pip \
     python3-future \
+    python3-wheel \
     libnet-devel \
     nftables-devel \
     protobuf-devel \
@@ -69,6 +70,7 @@ RUN yum -y update && yum install -y \
 
 RUN set -e \
     && cd /tmp \
+    && python3 -m pip install --upgrade pip \
     && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
     && mv criu criu-build \
     && cd criu-build && \

--- a/criu/ubi8/Dockerfile
+++ b/criu/ubi8/Dockerfile
@@ -67,15 +67,16 @@ RUN yum -y update && yum install -y \
     xmlto \
     libuuid-devel
 
-RUN cd /tmp; \
-    git clone -b ${CRIU_BRANCH} ${CRIU_REPO}; \
-    mv criu criu-build; \
-    cd criu-build; \
+RUN set -e \
+    && cd /tmp \
+    && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
+    && mv criu criu-build \
+    && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-         git reset --hard ${CRIU_SHA}; \
-    fi; \
-    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu; \
-    cd ../; \
-    tar -czf criu.tar.gz criu; \
-    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt; \
-    rm -fr criu-build;
+        git reset --hard ${CRIU_SHA} \
+    fi \
+    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    && cd ../ \
+    && tar -czf criu.tar.gz criu \
+    && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
+    && rm -rf criu-build

--- a/criu/ubi8/Dockerfile
+++ b/criu/ubi8/Dockerfile
@@ -73,9 +73,9 @@ RUN set -e \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA} \
-    fi \
-    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+        git reset --hard ${CRIU_SHA}; \
+    fi; \
+    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \

--- a/criu/ubi9/Dockerfile
+++ b/criu/ubi9/Dockerfile
@@ -51,6 +51,8 @@ RUN yum -y update && yum install -y \
     python3-protobuf \
     python3-pip \
     python3-future \
+    python3-setuptools \
+    python3-wheel \
     libnet-devel \
     nftables-devel \
     protobuf-devel \

--- a/criu/ubi9/Dockerfile
+++ b/criu/ubi9/Dockerfile
@@ -73,9 +73,9 @@ RUN set -e \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA} \
-    fi \
-    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+        git reset --hard ${CRIU_SHA}; \
+    fi; \
+    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \

--- a/criu/ubi9/Dockerfile
+++ b/criu/ubi9/Dockerfile
@@ -67,15 +67,16 @@ RUN yum -y update && yum install -y \
     xmlto \
     libuuid-devel
 
-RUN cd /tmp; \
-    git clone -b ${CRIU_BRANCH} ${CRIU_REPO}; \
-    mv criu criu-build; \
-    cd criu-build; \
+RUN set -e \
+    && cd /tmp \
+    && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
+    && mv criu criu-build \
+    && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA}; \
-    fi; \
-    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu; \
-    cd ../; \
-    tar -czf criu.tar.gz criu; \
-    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt; \
-    rm -fr criu-build;
+        git reset --hard ${CRIU_SHA} \
+    fi \
+    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    && cd ../ \
+    && tar -czf criu.tar.gz criu \
+    && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
+    && rm -rf criu-build

--- a/criu/ubuntu22/Dockerfile
+++ b/criu/ubuntu22/Dockerfile
@@ -72,15 +72,16 @@ RUN apt-get update && \
     vim \
     xmlto
 
-RUN cd /tmp; \
-    git clone -b ${CRIU_BRANCH} ${CRIU_REPO}; \
-    mv criu criu-build; \
-    cd criu-build; \
+RUN set -e \
+    && cd /tmp \
+    && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
+    && mv criu criu-build \
+    && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA}; \
-    fi; \
-    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu; \
-    cd ../; \
-    tar -czf criu.tar.gz criu; \
-    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt; \
-    rm -rf criu-build;
+        git reset --hard ${CRIU_SHA} \
+    fi \
+    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    && cd ../ \
+    && tar -czf criu.tar.gz criu \
+    && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
+    && rm -rf criu-build

--- a/criu/ubuntu22/Dockerfile
+++ b/criu/ubuntu22/Dockerfile
@@ -78,9 +78,9 @@ RUN set -e \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA} \
-    fi \
-    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+        git reset --hard ${CRIU_SHA}; \
+    fi; \
+    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \

--- a/criu/ubuntu24/Dockerfile
+++ b/criu/ubuntu24/Dockerfile
@@ -72,15 +72,16 @@ RUN apt-get update && \
     vim \
     xmlto
 
-RUN cd /tmp; \
-    git clone -b ${CRIU_BRANCH} ${CRIU_REPO}; \
-    mv criu criu-build; \
-    cd criu-build; \
+RUN set -e \
+    && cd /tmp \
+    && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
+    && mv criu criu-build \
+    && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA}; \
-    fi; \
-    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu; \
-    cd ../; \
-    tar -czf criu.tar.gz criu; \
-    sha256sum criu.tar.gz > criu.tar.gz.sha256.txt; \
-    rm -rf criu-build;
+        git reset --hard ${CRIU_SHA} \
+    fi \
+    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    && cd ../ \
+    && tar -czf criu.tar.gz criu \
+    && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
+    && rm -rf criu-build

--- a/criu/ubuntu24/Dockerfile
+++ b/criu/ubuntu24/Dockerfile
@@ -78,9 +78,9 @@ RUN set -e \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
-        git reset --hard ${CRIU_SHA} \
-    fi \
-    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+        git reset --hard ${CRIU_SHA}; \
+    fi; \
+    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \


### PR DESCRIPTION
 - related to: https://github.ibm.com/runtimes/automation/issues/949
 - remove libbsd package from ubi10
 - add new packages for ubi10
 - Replace `;` with `&&` in the `make` `RUN` command for catching failures

Signed-off-by: Aswin K R <aswinkr77@gmail.com>