### PR TITLE
update README with recent versions and copyright year to 2026

### DIFF
--- a/11/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/11/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/11/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubuntu/noble/Dockerfile.certified.releases.full
+++ b/11/jdk/ubuntu/noble/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2025, 2025
+# (C) Copyright IBM Corporation 2025, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/11/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2025, 2025
+# (C) Copyright IBM Corporation 2025, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/11/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/11/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/11/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/11/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/11/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/17/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/17/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/17/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/17/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi-minimal/ubi8/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/17/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi-minimal/ubi9/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/17/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/17/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.certified.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/17/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/17/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubi-minimal/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/8/jdk/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubi/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubi/ubi8/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubi/ubi9/Dockerfile.open.releases.full
+++ b/8/jdk/ubi/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubuntu/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubuntu/focal/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/focal/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/jammy/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jdk/ubuntu/noble/Dockerfile.open.releases.full
+++ b/8/jdk/ubuntu/noble/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2025, 2025
+# (C) Copyright IBM Corporation 2025, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubi-minimal/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
+++ b/8/jre/ubi-minimal/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubi/Dockerfile.open.releases.full
+++ b/8/jre/ubi/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubi/ubi8/Dockerfile.open.releases.full
+++ b/8/jre/ubi/ubi8/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubi/ubi9/Dockerfile.open.releases.full
+++ b/8/jre/ubi/ubi9/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubuntu/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubuntu/focal/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/focal/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubuntu/jammy/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/jammy/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2021, 2025
+# (C) Copyright IBM Corporation 2021, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/8/jre/ubuntu/noble/Dockerfile.open.releases.full
+++ b/8/jre/ubuntu/noble/Dockerfile.open.releases.full
@@ -1,4 +1,4 @@
-# (C) Copyright IBM Corporation 2025, 2025
+# (C) Copyright IBM Corporation 2025, 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
-# Containers
+# Semeru Containers
 
 This repository contains the Dockerfiles for the official IBM® Semeru Runtime™ Open Edition images. These images are made available in Dockerhub.
 
-## Supported Images
+## Supported Images 
 
-| OS | Version | Dockerfile |
-|---|---|---|
-|  Ubuntu 20.04 | JDK8 | [Dockerfile](./8/jdk/ubuntu/Dockerfile.open.releases.full) |
-|  Ubuntu 20.04 | JDK11 | [Dockerfile](./11/jdk/ubuntu/Dockerfile.open.releases.full) |
-|  Ubuntu 20.04 | JDK16 | [Dockerfile](./16/jdk/ubuntu/Dockerfile.open.releases.full) |
-|  Ubuntu 20.04 | JDK17 | [Dockerfile](./17/jdk/ubuntu/Dockerfile.open.releases.full) |
-|  Ubuntu 20.04 | JRE8 | [Dockerfile](./8/jre/ubuntu/Dockerfile.open.releases.full) |
-|  Ubuntu 20.04 | JRE11 | [Dockerfile](./11/jre/ubuntu/Dockerfile.open.releases.full) |
-|  Ubuntu 20.04 | JRE16 | [Dockerfile](./16/jre/ubuntu/Dockerfile.open.releases.full) |
-|  Ubuntu 20.04 | JRE17 | [Dockerfile](./17/jre/ubuntu/Dockerfile.open.releases.full) |
-|  Centos 7 | JDK8 | [Dockerfile](./8/jdk/centos/Dockerfile.open.releases.full) |
-|  Centos 7 | JDK11 | [Dockerfile](./11/jdk/centos/Dockerfile.open.releases.full) |
-|  Centos 7 | JDK16 | [Dockerfile](./16/jdk/centos/Dockerfile.open.releases.full) |
-|  Centos 7 | JDK17 | [Dockerfile](./17/jdk/centos/Dockerfile.open.releases.full) |
-|  Centos 7 | JRE8 | [Dockerfile](./8/jre/centos/Dockerfile.open.releases.full) |
-|  Centos 7 | JRE11 | [Dockerfile](./11/jre/centos/Dockerfile.open.releases.full) |
-|  Centos 7 | JRE16 | [Dockerfile](./16/jre/centos/Dockerfile.open.releases.full) |
-|  Centos 7 | JRE17 | [Dockerfile](./17/jre/centos/Dockerfile.open.releases.full) |
+### Ubuntu 22.04 (Jammy)
+
+| Java Version | JDK | JRE |
+|--------------|-----|-----|
+| Semeru 8 | [Dockerfile](./8/jdk/ubuntu/jammy/Dockerfile.open.releases.full) | [Dockerfile](./8/jre/ubuntu/jammy/Dockerfile.open.releases.full) |
+| Semeru 11 | [Dockerfile](./11/jdk/ubuntu/jammy/Dockerfile.open.releases.full) | [Dockerfile](./11/jre/ubuntu/jammy/Dockerfile.open.releases.full) |
+| Semeru 17 | [Dockerfile](./17/jdk/ubuntu/jammy/Dockerfile.open.releases.full) | [Dockerfile](./17/jre/ubuntu/jammy/Dockerfile.open.releases.full) |
+| Semeru 21 | [Dockerfile](./21/jdk/ubuntu/jammy/Dockerfile.open.releases.full) | [Dockerfile](./21/jre/ubuntu/jammy/Dockerfile.open.releases.full) |
+| Semeru 25 | [Dockerfile](./25/jdk/ubuntu/jammy/Dockerfile.open.releases.full) | [Dockerfile](./25/jre/ubuntu/jammy/Dockerfile.open.releases.full) |
+
+### Ubuntu 24.04 (Noble)
+
+| Java Version | JDK | JRE |
+|--------------|-----|-----|
+| Semeru 8 | [Dockerfile](./8/jdk/ubuntu/noble/Dockerfile.open.releases.full) | [Dockerfile](./8/jre/ubuntu/noble/Dockerfile.open.releases.full) |
+| Semeru 11 | [Dockerfile](./11/jdk/ubuntu/noble/Dockerfile.open.releases.full) | [Dockerfile](./11/jre/ubuntu/noble/Dockerfile.open.releases.full) |
+| Semeru 17 | [Dockerfile](./17/jdk/ubuntu/noble/Dockerfile.open.releases.full) | [Dockerfile](./17/jre/ubuntu/noble/Dockerfile.open.releases.full) |
+| Semeru 21 | [Dockerfile](./21/jdk/ubuntu/noble/Dockerfile.open.releases.full) | [Dockerfile](./21/jre/ubuntu/noble/Dockerfile.open.releases.full) |
+| Semeru 25 | [Dockerfile](./25/jdk/ubuntu/noble/Dockerfile.open.releases.full) | [Dockerfile](./25/jre/ubuntu/noble/Dockerfile.open.releases.full) |
+| Semeru 26 | [Dockerfile](./26/jdk/ubuntu/noble/Dockerfile.open.releases.full) | [Dockerfile](./26/jre/ubuntu/noble/Dockerfile.open.releases.full) |
 
 ## Issues
 Please See the [Semeru-Runtimes](https://github.com/ibmruntimes/Semeru-Runtimes) repo for issue reporting.


### PR DESCRIPTION
Changes : 
* Remove EOS Versions
* Add new Java versions
* Update Copyright year of modified files with 2026 year