### PR TITLE
Remove Python libraries as well as cherry picking

### DIFF
--- a/criu/centos9_stream/Dockerfile
+++ b/criu/centos9_stream/Dockerfile
@@ -20,7 +20,7 @@
 FROM quay.io/centos/centos:stream9
 
 ARG CRIU_REPO=https://github.com/ibmruntimes/criu.git
-ARG CRIU_BRANCH=upstream-master
+ARG CRIU_BRANCH=criu-dev
 # Last stable commit SHA
 ARG CRIU_SHA
 
@@ -64,6 +64,7 @@ RUN dnf -y update && \
     python3-pip \
     python3-protobuf \
     python3-PyYAML \
+    python3-wheel \
     vim \
     xmlto
 
@@ -77,6 +78,7 @@ RUN set -e \
     fi; \
     make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
+    && rm -rf /tmp/criu/usr/local/lib/python* \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
     && rm -rf criu-build

--- a/criu/sles15/Dockerfile
+++ b/criu/sles15/Dockerfile
@@ -20,7 +20,7 @@
 FROM registry.suse.com/suse/sle15:15.7
 
 ARG CRIU_REPO=https://github.com/ibmruntimes/criu.git
-ARG CRIU_BRANCH=upstream-master
+ARG CRIU_BRANCH=criu-dev
 # Last stable commit SHA
 ARG CRIU_SHA
 
@@ -69,6 +69,7 @@ RUN zypper update -y && \
     python311-pip \
     python311-protobuf \
     python311-PyYAML \
+    python311-wheel \
     vim \
     xmlto
 
@@ -83,8 +84,9 @@ RUN set -e \
     if [ "x${CRIU_SHA}" != x ] ; then \
         git reset --hard ${CRIU_SHA}; \
     fi; \
-    && make CC=/usr/bin/gcc-13 DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    make CC=/usr/bin/gcc-13 DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
+    && rm -rf /tmp/criu/usr/local/lib/python* \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
     && rm -rf criu-build

--- a/criu/sles16/Dockerfile
+++ b/criu/sles16/Dockerfile
@@ -22,7 +22,7 @@ FROM registry.suse.com/bci/bci-base:16.0
 WORKDIR /tmp
 
 ARG CRIU_REPO=https://github.com/ibmruntimes/criu.git
-ARG CRIU_BRANCH=upstream-master
+ARG CRIU_BRANCH=criu-dev
 # Last stable commit SHA
 ARG CRIU_SHA
 
@@ -80,18 +80,15 @@ RUN zypper --gpg-auto-import-keys refresh && \
 RUN set -e \
     && cd /tmp \
     && python3 -m pip install --upgrade pip setuptools \
-    && git config --global user.email "$(hostname)@$(hostname).com" \
     && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
         git reset --hard ${CRIU_SHA}; \
     fi; \
-    git remote add upstream https://github.com/checkpoint-restore/criu.git \
-    && git fetch upstream criu-dev \
-    && git cherry-pick d3dfb663b1022ec89431a0e61113f55a771bc73c \
-    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
+    && rm -rf /tmp/criu/usr/local/lib/python* \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
     && rm -rf criu-build

--- a/criu/ubuntu22/Dockerfile
+++ b/criu/ubuntu22/Dockerfile
@@ -20,7 +20,7 @@
 FROM public.ecr.aws/ubuntu/ubuntu:22.04
 
 ARG CRIU_REPO=https://github.com/ibmruntimes/criu.git
-ARG CRIU_BRANCH=upstream-master
+ARG CRIU_BRANCH=criu-dev
 # Last stable commit SHA
 ARG CRIU_SHA
 
@@ -82,6 +82,7 @@ RUN set -e \
     fi; \
     make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
+    && rm -rf /tmp/criu/usr/local/lib/python* \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
     && rm -rf criu-build

--- a/criu/ubuntu24/Dockerfile
+++ b/criu/ubuntu24/Dockerfile
@@ -20,7 +20,7 @@
 FROM public.ecr.aws/ubuntu/ubuntu:24.04
 
 ARG CRIU_REPO=https://github.com/ibmruntimes/criu.git
-ARG CRIU_BRANCH=upstream-master
+ARG CRIU_BRANCH=criu-dev
 # Last stable commit SHA
 ARG CRIU_SHA
 
@@ -82,6 +82,7 @@ RUN set -e \
     fi; \
     make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
+    && rm -rf /tmp/criu/usr/local/lib/python* \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
     && rm -rf criu-build

--- a/criu/ubuntu26/Dockerfile
+++ b/criu/ubuntu26/Dockerfile
@@ -20,7 +20,7 @@
 FROM public.ecr.aws/ubuntu/ubuntu:26.04
 
 ARG CRIU_REPO=https://github.com/ibmruntimes/criu.git
-ARG CRIU_BRANCH=upstream-master
+ARG CRIU_BRANCH=criu-dev
 # Last stable commit SHA
 ARG CRIU_SHA
 
@@ -74,17 +74,13 @@ RUN apt-get update && \
 
 RUN set -e \
     && cd /tmp \
-    && git config --global user.email "$(hostname)@$(hostname).com" \
     && git clone -b ${CRIU_BRANCH} ${CRIU_REPO} \
     && mv criu criu-build \
     && cd criu-build && \
     if [ "x${CRIU_SHA}" != x ] ; then \
         git reset --hard ${CRIU_SHA}; \
     fi; \
-    git remote add upstream https://github.com/checkpoint-restore/criu.git \
-    && git fetch upstream criu-dev \
-    && git cherry-pick 90300748effc1cf0fe56e35d3d1cc2ddfedab246 3f3acc3200a23140abaa32a2017ae159d3c2d02c \
-    && make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
+    make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \

--- a/criu/ubuntu26/Dockerfile
+++ b/criu/ubuntu26/Dockerfile
@@ -82,6 +82,7 @@ RUN set -e \
     fi; \
     make DESTDIR=/tmp/criu PREFIX=/usr/local LIBDIR=/usr/local/lib64 install-lib install-criu \
     && cd ../ \
+    && rm -rf /tmp/criu/usr/local/lib/python* \
     && tar -czf criu.tar.gz criu \
     && sha256sum criu.tar.gz > criu.tar.gz.sha256.txt \
     && rm -rf criu-build


### PR DESCRIPTION
 - remove python libraries from other distros as well
 - change default criu branch to criu-dev
 - remove cherry pick commits
 - add new python3-wheel package support for the relevant distros

Signed-off-by: Aswin K R <aswinkr77@gmail.com>