### PR TITLE
Remove deprecated iptables packages; use nftables as the alternative from UBI10 Dockerfiles

### DIFF
--- a/11/jdk/ubi/ubi10/Dockerfile.certified.releases.full
+++ b/11/jdk/ubi/ubi10/Dockerfile.certified.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/11/jdk/ubi/ubi10/Dockerfile.open.releases.full
+++ b/11/jdk/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/11/jre/ubi/ubi10/Dockerfile.certified.releases.full
+++ b/11/jre/ubi/ubi10/Dockerfile.certified.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/11/jre/ubi/ubi10/Dockerfile.open.releases.full
+++ b/11/jre/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/17/jdk/ubi/ubi10/Dockerfile.certified.releases.full
+++ b/17/jdk/ubi/ubi10/Dockerfile.certified.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/17/jdk/ubi/ubi10/Dockerfile.open.releases.full
+++ b/17/jdk/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/17/jre/ubi/ubi10/Dockerfile.certified.releases.full
+++ b/17/jre/ubi/ubi10/Dockerfile.certified.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/17/jre/ubi/ubi10/Dockerfile.open.releases.full
+++ b/17/jre/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/21/jdk/ubi/ubi10/Dockerfile.certified.releases.full
+++ b/21/jdk/ubi/ubi10/Dockerfile.certified.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/21/jdk/ubi/ubi10/Dockerfile.open.releases.full
+++ b/21/jdk/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/21/jre/ubi/ubi10/Dockerfile.certified.releases.full
+++ b/21/jre/ubi/ubi10/Dockerfile.certified.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/21/jre/ubi/ubi10/Dockerfile.open.releases.full
+++ b/21/jre/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/25/jdk/ubi/ubi10/Dockerfile.certified.releases.full
+++ b/25/jdk/ubi/ubi10/Dockerfile.certified.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/25/jdk/ubi/ubi10/Dockerfile.open.releases.full
+++ b/25/jdk/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/25/jre/ubi/ubi10/Dockerfile.certified.releases.full
+++ b/25/jre/ubi/ubi10/Dockerfile.certified.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/25/jre/ubi/ubi10/Dockerfile.open.releases.full
+++ b/25/jre/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/26/jdk/ubi/ubi10/Dockerfile.open.releases.full
+++ b/26/jdk/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;

--- a/26/jre/ubi/ubi10/Dockerfile.open.releases.full
+++ b/26/jre/ubi/ubi10/Dockerfile.open.releases.full
@@ -19,7 +19,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN dnf install -y \
     # CRIU dependencies
-        iptables-libs iptables jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
+        iptables-libs jansson libibverbs libmnl libnet libnftnl libpcap nftables protobuf-c \
     # Semeru dependencies
         tzdata openssl ca-certificates fontconfig glibc-langpack-en gzip tar \
     && dnf update -y && dnf clean all;


### PR DESCRIPTION
Remove deprecated iptables packages from ubi10 dockerfiles; using exising nftables as the alternative.